### PR TITLE
Idempotency test for serialization of presentation definitions

### DIFF
--- a/crates/credentials/Cargo.toml
+++ b/crates/credentials/Cargo.toml
@@ -11,3 +11,6 @@ jsonschema = "0.17.1"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_with = "3.4.0"
+
+[dev-dependencies]
+serde_canonical_json = "1.0.0"


### PR DESCRIPTION

Modified a test so that it mimics what was done in `web5-kt` (see https://github.com/TBD54566975/web5-kt/blob/a644e6f129cabc85906099d8e79497a1d18fff71/credentials/src/test/kotlin/web5/sdk/credentials/PresentationDefinitionTest.kt#L56)

The idea behind this test is that it ensures that fields weren't misspelled, or missed, from the `PresentationDefinition` struct. It also showcases:
* how to use a dependency that's only for testing purposes. 
* How to do canonicalization of JSON. 