### PR TITLE
Resolve did:web

### DIFF
--- a/crates/dids/Cargo.toml
+++ b/crates/dids/Cargo.toml
@@ -10,6 +10,7 @@ license-file.workspace = true
 async-trait = "0.1.74"
 crypto = { path = "../crypto" }
 did-jwk = "0.1.1"
+did-web = "0.2.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 ssi-dids = "0.1.1"

--- a/crates/dids/src/method/mod.rs
+++ b/crates/dids/src/method/mod.rs
@@ -1,4 +1,5 @@
 pub mod jwk;
+pub mod web;
 
 use crate::did::Did;
 use crate::resolver::DidResolutionResult;

--- a/crates/dids/src/method/web.rs
+++ b/crates/dids/src/method/web.rs
@@ -1,0 +1,82 @@
+use crate::did::Did;
+use crate::method::{DidMethod, DidMethodError, DidResolutionResult};
+use async_trait::async_trait;
+use crypto::key_manager::KeyManager;
+use did_web::DIDWeb as SpruceDidWebMethod;
+use ssi_dids::did_resolve::{DIDResolver, ResolutionInputMetadata};
+use std::sync::Arc;
+
+/// Concrete implementation for a did:web DID
+pub struct DidWeb {
+    uri: String,
+    key_manager: Arc<dyn KeyManager>,
+}
+
+impl Did for DidWeb {
+    fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    fn key_manager(&self) -> &Arc<dyn KeyManager> {
+        &self.key_manager
+    }
+}
+
+/// Options that can be used to create a did:web DID.
+/// This is currently a unit struct because did:web does not support key creation.
+pub struct DidWebCreateOptions;
+
+#[async_trait]
+impl DidMethod<DidWeb, DidWebCreateOptions> for DidWeb {
+    const NAME: &'static str = "web";
+
+    fn create(
+        _key_manager: Arc<dyn KeyManager>,
+        _options: DidWebCreateOptions,
+    ) -> Result<DidWeb, DidMethodError> {
+        Err(DidMethodError::DidCreationFailure(
+            "create operation not supported for did:web".to_string(),
+        ))
+    }
+
+    async fn resolve_uri(did_uri: &str) -> DidResolutionResult {
+        let input_metadata = ResolutionInputMetadata::default();
+        let (did_resolution_metadata, did_document, did_document_metadata) =
+            SpruceDidWebMethod.resolve(did_uri, &input_metadata).await;
+
+        DidResolutionResult {
+            did_resolution_metadata,
+            did_document,
+            did_document_metadata,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_fails() {
+        let key_manager = Arc::new(crypto::key_manager::LocalKeyManager::new_in_memory());
+        let result = DidWeb::create(key_manager, DidWebCreateOptions);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolution_success() {
+        let did_uri = "did:web:tbd.website";
+        let result = DidWeb::resolve_uri(did_uri).await;
+        assert!(result.did_resolution_metadata.error.is_none());
+
+        let did_document = result.did_document.expect("did_document not found");
+        assert_eq!(did_document.id, did_uri);
+    }
+
+    #[tokio::test]
+    async fn resolution_failure() {
+        let result = DidWeb::resolve_uri("did:web:does-not-exist").await;
+        assert!(result.did_resolution_metadata.error.is_some());
+    }
+}

--- a/crates/dids/src/resolver.rs
+++ b/crates/dids/src/resolver.rs
@@ -1,4 +1,5 @@
 use crate::method::jwk::DidJwk;
+use crate::method::web::DidWeb;
 use crate::method::DidMethod;
 use serde::{Deserialize, Serialize};
 use ssi_dids::did_resolve::{
@@ -18,6 +19,7 @@ impl DidResolver {
 
         match method_name {
             DidJwk::NAME => DidJwk::resolve_uri(did_uri).await,
+            DidWeb::NAME => DidWeb::resolve_uri(did_uri).await,
             _ => return DidResolutionResult::from_error(ERROR_METHOD_NOT_SUPPORTED),
         }
     }
@@ -80,6 +82,16 @@ mod tests {
     #[tokio::test]
     async fn resolve_did_jwk() {
         let did_uri = "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9";
+        let result = DidResolver::resolve_uri(did_uri).await;
+        assert!(result.did_resolution_metadata.error.is_none());
+
+        let did_document = result.did_document.unwrap();
+        assert_eq!(did_document.id, did_uri);
+    }
+
+    #[tokio::test]
+    async fn resolve_did_web() {
+        let did_uri = "did:web:tbd.website";
         let result = DidResolver::resolve_uri(did_uri).await;
         assert!(result.did_resolution_metadata.error.is_none());
 


### PR DESCRIPTION
Resolve `did:web` DIDs using Spruce's [did-web](https://crates.io/crates/did-web) crate. Uses our `DidResolutionResult` implementation so that the resolved DIDDocument & all respective metadata is in the expected format according to the community draft resolution spec [here](https://w3c-ccg.github.io/did-resolution/#resolving).

Resolves https://github.com/TBD54566975/web5-rs/issues/12