### PR TITLE
Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: SDK Rust CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: cargo test
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        rust: [stable, nightly]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Test
+        run: cargo test --workspace
+  format:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rustfmt
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Rustfmt Check
+        id: rustfmt-check
+        uses: actions-rust-lang/rustfmt@v1

--- a/crates/credentials/src/pex/v2/presentation_definition.rs
+++ b/crates/credentials/src/pex/v2/presentation_definition.rs
@@ -145,11 +145,11 @@ pub enum Optionality {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_canonical_json::CanonicalFormatter;
+    use serde_json::Serializer;
     use serde_json::{json, Value};
     use std::fs;
     use std::path::Path;
-    use serde_json::Serializer;
-    use serde_canonical_json::CanonicalFormatter;
 
     #[test]
     fn can_serialize() {
@@ -191,7 +191,8 @@ mod tests {
         let json_value = String::from_utf8(ser.into_inner()).unwrap();
 
         let mut ser = Serializer::with_formatter(Vec::new(), CanonicalFormatter::new());
-        let deserialized_with_type: PresentationDefinition = serde_json::from_str(&raw_string).unwrap();
+        let deserialized_with_type: PresentationDefinition =
+            serde_json::from_str(&raw_string).unwrap();
         deserialized_with_type.serialize(&mut ser).unwrap();
         let json_serialized_from_type = String::from_utf8(ser.into_inner()).unwrap();
 

--- a/crates/dids/src/lib.rs
+++ b/crates/dids/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: usize, right: usize)      -> usize {
     left + right
 }
 

--- a/crates/dids/src/lib.rs
+++ b/crates/dids/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize)      -> usize {
+pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
 


### PR DESCRIPTION
Add Github actions to do the following:
* Run `cargo test --workspace`, to run all the tests within this Rust workspace.
* Run `cargo fmt --all` and report all formatting differences in a nice overview on the Action Summary page.
    * Example: https://github.com/TBD54566975/web5-rs/actions/runs/7066281188

There were formatting issues in the repo, so I went ahead and ran the formatter and committed the fixes!