### PR TITLE
clippy/test fixes for main branch

### DIFF
--- a/crates/dids/src/method/jwk.rs
+++ b/crates/dids/src/method/jwk.rs
@@ -72,10 +72,11 @@ impl DidMethod<DidJwk, DidJwkCreateOptions> for DidJwk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crypto::key_manager::local_key_manager::LocalKeyManager;
     use ssi_dids::did_resolve::ERROR_INVALID_DID;
 
     fn create_did_jwk() -> DidJwk {
-        let key_manager = Arc::new(crypto::key_manager::LocalKeyManager::new_in_memory());
+        let key_manager = Arc::new(LocalKeyManager::new_in_memory());
         let options = DidJwkCreateOptions {
             key_type: KeyType::Ed25519,
         };

--- a/crates/dids/src/method/jwk.rs
+++ b/crates/dids/src/method/jwk.rs
@@ -47,7 +47,7 @@ impl DidMethod<DidJwk, DidJwkCreateOptions> for DidJwk {
                 ))?;
 
         let uri = SpruceDidJwkMethod
-            .generate(&Source::Key(&public_key.jwk()))
+            .generate(&Source::Key(public_key.jwk()))
             .ok_or(DidMethodError::DidCreationFailure(
                 "Failed to generate did:jwk".to_string(),
             ))?;

--- a/crates/dids/src/method/web.rs
+++ b/crates/dids/src/method/web.rs
@@ -56,10 +56,11 @@ impl DidMethod<DidWeb, DidWebCreateOptions> for DidWeb {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crypto::key_manager::local_key_manager::LocalKeyManager;
 
     #[test]
     fn create_fails() {
-        let key_manager = Arc::new(crypto::key_manager::LocalKeyManager::new_in_memory());
+        let key_manager = Arc::new(LocalKeyManager::new_in_memory());
         let result = DidWeb::create(key_manager, DidWebCreateOptions);
         assert!(result.is_err());
     }

--- a/crates/dids/src/resolver.rs
+++ b/crates/dids/src/resolver.rs
@@ -20,7 +20,7 @@ impl DidResolver {
         match method_name {
             DidJwk::NAME => DidJwk::resolve_uri(did_uri).await,
             DidWeb::NAME => DidWeb::resolve_uri(did_uri).await,
-            _ => return DidResolutionResult::from_error(ERROR_METHOD_NOT_SUPPORTED),
+            _ => DidResolutionResult::from_error(ERROR_METHOD_NOT_SUPPORTED),
         }
     }
 


### PR DESCRIPTION
There was a bit of a merge race between the PR that added clippy & the Did methods PRs. Looks like a few lint issues & test compilation issues got through. 

This PR fixes those by running:
`cargo clippy --fix` 

The two linting issues were due to:
* `public_key.jwk()` is already a reference, so it doesn't need to be borrowed again
* unnecessary `return` 

The build error in tests was due to `LocalKeyManager`'s use path changing.