### PR TITLE
Create a uniffi-bindgen crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ thiserror = "1.0.50"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_with = "3.4.0"
+
+# Update to released version once foreign traits are included (likely 0.26.0).
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "7cd3aac735e905e1725d350a7a82d57aa50caaa1" }

--- a/bindings/uniffi-bindgen/Cargo.toml
+++ b/bindings/uniffi-bindgen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uniffi-bindgen"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "src/uniffi-bindgen.rs"
+
+[dependencies]
+uniffi = { workspace = true, features = ["cli"] }

--- a/bindings/uniffi-bindgen/src/uniffi-bindgen.rs
+++ b/bindings/uniffi-bindgen/src/uniffi-bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}


### PR DESCRIPTION
We will be using [`uniffi-rs`](https://github.com/mozilla/uniffi-rs) to generate bindings, allowing foreign languages to be able to call into our Rust code. Our first target language will be Swift, so that tbDEX can be used on Apple platforms.

For more information on `uniffi`, check out their excellent user guide: https://mozilla.github.io/uniffi-rs/Overview.html

This PR does the setup for multi-crate workspace, as outlined in their user guide here: https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html#multi-crate-workspaces