### PR TITLE
Add `audit` job to security.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1.4.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run audit
+        run: cargo audit
   test:
     name: cargo test
     strategy:


### PR DESCRIPTION
This PR sets up an `audit` job inside the `security` workflow which is run by github actions.

Ideally, this would be done via snyk, but it  isn't supported for rust. Instead, we'll use `cargo audit`.

`cargo audit` (see https://lib.rs/crates/cargo-audit) appears to be a well known tool that can start preventing attacks. The initial run shows that the `did-jwk` dependency has a vulnerability on the `rsa` sub-dependency.

