### PR TITLE
Don't allow private keys to leave the KeyStore

### DIFF
--- a/crates/dids/src/method/jwk.rs
+++ b/crates/dids/src/method/jwk.rs
@@ -31,12 +31,7 @@ impl Method<DidJwkCreateOptions> for DidJwk {
         options: DidJwkCreateOptions,
     ) -> Result<BearerDid, MethodError> {
         let key_alias = key_manager.generate_private_key(options.curve)?;
-        let public_key =
-            key_manager
-                .get_public_key(&key_alias)?
-                .ok_or(MethodError::DidCreationFailure(
-                    "PublicKey not found".to_string(),
-                ))?;
+        let public_key = key_manager.get_public_key(&key_alias)?;
 
         let jwk_string = public_key.to_json().map_err(|_| {
             MethodError::DidCreationFailure("failed to serialize public jwk".to_string())

--- a/crates/keys/src/key_manager/key_store/mod.rs
+++ b/crates/keys/src/key_manager/key_store/mod.rs
@@ -1,25 +1,30 @@
 pub mod in_memory_key_store;
 
-use crate::key::PrivateKey;
+use josekit::jws::JwsSigner;
+
+use crate::key::{Curve, KeyError, PublicKey};
 use std::sync::Arc;
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum KeyStoreError {
     #[error("{0}")]
     InternalKeyStoreError(String),
+    #[error(transparent)]
+    KeyError(#[from] KeyError),
+    #[error("key not found {0}")]
+    KeyNotFound(String)
 }
 
 // Trait for storing and retrieving private keys.
 //
 // Implementations of this trait should be thread-safe and allow for concurrent access.
 pub trait KeyStore: Send + Sync {
-    fn get(&self, key_alias: &str) -> Result<Option<Arc<dyn PrivateKey>>, KeyStoreError>;
-    fn insert(
+    fn generate_new(&self, curve: Curve) -> Result<String, KeyStoreError>;
+    fn get_all_aliases(&self) -> Result<Vec<String>, KeyStoreError>;
+    fn sign(&self, key_alias: &str, payload: &[u8]) -> Result<Vec<u8>, KeyStoreError>;
+    fn get_public_key(
         &self,
         key_alias: &str,
-        private_key: Arc<dyn PrivateKey>,
-    ) -> Result<(), KeyStoreError>;
+    ) -> Result<Arc<dyn PublicKey>, KeyStoreError>;
+    fn get_jws_signer(&self, key_alias: &str) -> Result<Arc<dyn JwsSigner>, KeyStoreError>;
 }
-
-// todo I don't think we should enable private keys to ever leave the KeyStore, 
-//      so `get` doesn't make sense and `insert` should be replaced with a `generate()` method

--- a/crates/keys/src/key_manager/mod.rs
+++ b/crates/keys/src/key_manager/mod.rs
@@ -34,7 +34,7 @@ pub trait KeyManager: Send + Sync {
     fn get_public_key(
         &self,
         key_alias: &str,
-    ) -> Result<Option<Arc<dyn PublicKey>>, KeyManagerError>;
+    ) -> Result<Arc<dyn PublicKey>, KeyManagerError>;
 
     /// Signs the provided payload using the private key identified by the provided `key_alias`.
     fn sign(&self, key_alias: &str, payload: &[u8]) -> Result<Vec<u8>, KeyManagerError>;


### PR DESCRIPTION
Basically this neuters the concept of a `KeyManager` as a proxy layer into the `KeyStore` but I think it will be worthy if we find ourselves in a place of wanting a `KeyManager` that manages multiple different `KeyStore`'s