### PR TITLE
Remove async-trait in favor of impl Future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/TBD54566975/web5-rs.git"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-async-trait = "0.1.74"
 base64 = "0.22.0"
 chrono = { version = "0.4.37", features = ["std"] }
 thiserror = "1.0.50"

--- a/crates/dids/Cargo.toml
+++ b/crates/dids/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 crypto = { path = "../crypto" }
 did-jwk = "0.1.1"
 did-web = "0.2.2"

--- a/crates/dids/src/method/mod.rs
+++ b/crates/dids/src/method/mod.rs
@@ -4,9 +4,11 @@ pub mod web;
 
 use crate::bearer::BearerDid;
 use crate::resolver::ResolutionResult;
-use async_trait::async_trait;
-use keys::{key::KeyError, key_manager::{KeyManager, KeyManagerError}};
-use std::sync::Arc;
+use keys::{
+    key::KeyError,
+    key_manager::{KeyManager, KeyManagerError},
+};
+use std::{future::Future, sync::Arc};
 
 /// Errors that can occur when working with DID methods.
 #[derive(thiserror::Error, Debug)]
@@ -20,7 +22,6 @@ pub enum MethodError {
 }
 
 /// A trait with common behavior across all DID methods.
-#[async_trait]
 pub trait Method<CreateOptions> {
     /// The name of the implemented DID method (e.g. `jwk`).
     ///
@@ -41,5 +42,5 @@ pub trait Method<CreateOptions> {
 
     /// Resolve a DID URI to a [`DidResolutionResult`], as specified in
     /// [Resolving a DID](https://w3c-ccg.github.io/did-resolution/#resolving).
-    async fn resolve(did_uri: &str) -> ResolutionResult;
+    fn resolve(did_uri: &str) -> impl Future<Output = ResolutionResult>;
 }

--- a/crates/jws/Cargo.toml
+++ b/crates/jws/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 base64 = { workspace = true }
 crypto = { path = "../crypto" }
 dids = { path = "../dids" }

--- a/crates/jwt/Cargo.toml
+++ b/crates/jwt/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 base64 = { workspace = true }
 dids = { path = "../dids" }
 jws = { path = "../jws" }


### PR DESCRIPTION
wasm incompatibilities, could decorate with the below, but why not just use the standard lib

```rs
#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
```