### PR TITLE
Add 'Any' type for JSON serializable types

### DIFF
--- a/bindings/uniffi/Cargo.toml
+++ b/bindings/uniffi/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
+any = { path = "../../crates/any" }
 credentials = { path = "../../crates/credentials" }
 crypto = { path = "../../crates/crypto" }
 dids = { path = "../../crates/dids" }

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -1,3 +1,4 @@
+use ::any::{Any, AnyError};
 use ::credentials::vc::{verify_vcjwt, CredentialError, CredentialSubject, VerifiableCredential};
 use ::crypto::Curve;
 use ::dids::{

--- a/bindings/uniffi/src/web5.udl
+++ b/bindings/uniffi/src/web5.udl
@@ -12,6 +12,16 @@ namespace web5 {
 };
 
 [Error]
+enum AnyError {
+  "SerdeError",
+};
+
+interface Any {
+  [Name=from_json_string, Throws=AnyError]
+  constructor(string json_string);
+};
+
+[Error]
 enum KeyError {
     "KeyGenerationFailed",
     "SerializationFailed",

--- a/crates/any/Cargo.toml
+++ b/crates/any/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "any"
+version = "0.1.0"
+edition = "2021"
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/any/src/lib.rs
+++ b/crates/any/src/lib.rs
@@ -1,0 +1,127 @@
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+#[derive(thiserror::Error, Debug)]
+pub enum AnyError {
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Any {
+    pub value: Value,
+}
+
+impl Serialize for Any {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.value.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Any {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Value::deserialize(deserializer).map(|value| Any { value })
+    }
+}
+
+impl Any {
+    pub fn from_json_string(json_string: String) -> Result<Self, AnyError> {
+        let value: Value = serde_json::from_str(&json_string)?;
+        Ok(Self { value })
+    }
+
+    pub fn from_generic<T: Serialize + DeserializeOwned>(any: T) -> Result<Self, AnyError> {
+        let json_str = serde_json::to_string(&any)?;
+        let value = serde_json::from_str(&json_str)?;
+        Ok(Self { value })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_serialize_simple_values() {
+        let any = Any {
+            value: json!("hello"),
+        };
+        let serialized = serde_json::to_string(&any).unwrap();
+        assert_eq!(serialized, "\"hello\"");
+    }
+
+    #[test]
+    fn test_serialize_complex_object() {
+        let any = Any {
+            value: json!({"key": "value", "number": 10}),
+        };
+        let serialized = serde_json::to_string(&any).unwrap();
+        assert_eq!(serialized, "{\"key\":\"value\",\"number\":10}");
+    }
+
+    #[test]
+    fn test_deserialize_simple_values() {
+        let json_str = "\"hello\"";
+        let any: Any = serde_json::from_str(json_str).unwrap();
+        assert_eq!(any.value, json!("hello"));
+    }
+
+    #[test]
+    fn test_deserialize_complex_object() {
+        let json_str = "{\"key\":\"value\",\"number\":10}";
+        let any: Any = serde_json::from_str(json_str).unwrap();
+        assert_eq!(any.value, json!({"key": "value", "number": 10}));
+    }
+
+    #[test]
+    fn test_from_json_string_error_handling() {
+        let json_str = "not a valid json";
+        let result = Any::from_json_string(json_str.to_string());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_generic_conversion() {
+        let data = vec![1, 2, 3];
+        let any = Any::from_generic(data).unwrap();
+        assert_eq!(any.value, json!([1, 2, 3]));
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct TestStruct {
+        id: u32,
+        name: String,
+    }
+
+    #[test]
+    fn test_serialize_custom_struct() {
+        let test_struct = TestStruct {
+            id: 123,
+            name: "Alice".to_string(),
+        };
+        let any = Any::from_generic(test_struct).unwrap();
+        let serialized = serde_json::to_string(&any).unwrap();
+        assert_eq!(serialized, "{\"id\":123,\"name\":\"Alice\"}");
+    }
+
+    #[test]
+    fn test_deserialize_custom_struct() {
+        let json_str = "{\"id\":123,\"name\":\"Alice\"}";
+        let any: Any = serde_json::from_str(json_str).unwrap();
+        let deserialized: TestStruct = serde_json::from_value(any.value).unwrap();
+        assert_eq!(
+            deserialized,
+            TestStruct {
+                id: 123,
+                name: "Alice".to_string()
+            }
+        );
+    }
+}

--- a/web5-rs.code-workspace
+++ b/web5-rs.code-workspace
@@ -14,6 +14,9 @@
       "path": "examples"
     },
     {
+      "path": "crates/any"
+    },
+    {
       "path": "crates/credentials"
     },
     {


### PR DESCRIPTION
Originated from this PR https://github.com/TBD54566975/web5-rs/pull/130

We have needs for a general "any" type. The intent here is to create a solution which is compatible both in a pure rust development environment but also in a UniFFI binding project.

There is a question of: "_should we place this in `bindings/uniffi` instead? because it seems to be a constraint specific to UniFFI_"

The problem is on this line in `web5.udl`

```udl
interface VerifiableCredential {
  constructor(sequence<string> context, string id, sequence<string> type, string issuer, i64 issuance_date, i64? expiration_date, CredentialSubject credential_subject);
```

From @decentralgabe's comment here:

> 1. Pure native rust (with generics)
> 2. Bindings (with optional translation code to make the bindings nice)
> 3. Consumption of bindings
> 4. Idiomatic API surface in target language

I have had a stretch goal of limiting the burden on layer (2) to solely associated functions because leveraging the `constructor` feature in UDL means the binded language can do a traditional `VerifiableCredential(...params)`. But in order for us to leverage the `constructor` feature, the `crates/credentials/src/vc.rs` would have to inline the `Any` type in it's code. And if `Any` lives in `bindings/uniffi` crate then that means our core crate now has a dependency on the UniFFI bindings crate. Which is no bueno.

All of this to say, bindings really turns us into a pretzel. This PR is intended to spur discovery, we may choose to decline merging this. We need to establish patterns which are repeatable.