### PR TITLE
feat: separate DID Method trait from Create trait for create-able DIDs

### DIFF
--- a/crates/credentials/src/vc.rs
+++ b/crates/credentials/src/vc.rs
@@ -133,7 +133,7 @@ mod test {
         document::VerificationMethodType,
         method::{
             jwk::{DidJwk, DidJwkCreateOptions},
-            Method,
+            Create,
         },
     };
     use keys::key_manager::local_key_manager::LocalKeyManager;

--- a/crates/dids/src/bearer.rs
+++ b/crates/dids/src/bearer.rs
@@ -69,7 +69,7 @@ mod test {
         document::VerificationMethodType,
         method::{
             jwk::{DidJwk, DidJwkCreateOptions},
-            Method,
+            Create,
         },
     };
     use crypto::Curve;

--- a/crates/dids/src/method/jwk.rs
+++ b/crates/dids/src/method/jwk.rs
@@ -20,10 +20,8 @@ pub struct DidJwkCreateOptions {
     pub curve: Curve,
 }
 
-impl Method<DidJwkCreateOptions> for DidJwk {
-    const NAME: &'static str = "jwk";
-
-    fn create(
+impl DidJwk {
+    pub fn create(
         key_manager: Arc<dyn KeyManager>,
         options: DidJwkCreateOptions,
     ) -> Result<BearerDid, MethodError> {
@@ -63,6 +61,10 @@ impl Method<DidJwkCreateOptions> for DidJwk {
 
         Ok(bearer_did)
     }
+}
+
+impl Method for DidJwk {
+    const NAME: &'static str = "jwk";
 
     async fn resolve(did_uri: &str) -> ResolutionResult {
         let input_metadata = ResolutionInputMetadata::default();

--- a/crates/dids/src/method/jwk.rs
+++ b/crates/dids/src/method/jwk.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
-use crate::document::{Document, VerificationMethod};
 use crate::identifier::Identifier;
-use crate::method::{Method, MethodError};
+use crate::method::{MethodError, Resolve};
 use crate::resolver::ResolutionResult;
 use crate::{bearer::BearerDid, method::Create};
+use crate::{
+    document::{Document, VerificationMethod},
+    method::Method,
+};
 use crypto::Curve;
 use did_jwk::DIDJWK as SpruceDidJwkMethod;
 use keys::key_manager::KeyManager;
@@ -19,6 +22,10 @@ pub struct DidJwk;
 /// Options that can be used to create a did:jwk DID
 pub struct DidJwkCreateOptions {
     pub curve: Curve,
+}
+
+impl Method for DidJwk {
+    const NAME: &'static str = "jwk";
 }
 
 impl Create<DidJwkCreateOptions> for DidJwk {
@@ -64,9 +71,7 @@ impl Create<DidJwkCreateOptions> for DidJwk {
     }
 }
 
-impl Method for DidJwk {
-    const NAME: &'static str = "jwk";
-
+impl Resolve for DidJwk {
     async fn resolve(did_uri: &str) -> ResolutionResult {
         let input_metadata = ResolutionInputMetadata::default();
         let (spruce_resolution_metadata, spruce_document, spruce_document_metadata) =

--- a/crates/dids/src/method/jwk.rs
+++ b/crates/dids/src/method/jwk.rs
@@ -1,8 +1,10 @@
-use crate::bearer::BearerDid;
+use std::sync::Arc;
+
 use crate::document::{Document, VerificationMethod};
 use crate::identifier::Identifier;
 use crate::method::{Method, MethodError};
 use crate::resolver::ResolutionResult;
+use crate::{bearer::BearerDid, method::Create};
 use crypto::Curve;
 use did_jwk::DIDJWK as SpruceDidJwkMethod;
 use keys::key_manager::KeyManager;
@@ -10,7 +12,6 @@ use serde_json::from_str;
 use ssi_dids::did_resolve::{DIDResolver, ResolutionInputMetadata};
 use ssi_dids::{DIDMethod, Source};
 use ssi_jwk::JWK as SpruceJwk;
-use std::sync::Arc;
 
 /// Concrete implementation for a did:jwk DID
 pub struct DidJwk;
@@ -20,8 +21,8 @@ pub struct DidJwkCreateOptions {
     pub curve: Curve,
 }
 
-impl DidJwk {
-    pub fn create(
+impl Create<DidJwkCreateOptions> for DidJwk {
+    fn create(
         key_manager: Arc<dyn KeyManager>,
         options: DidJwkCreateOptions,
     ) -> Result<BearerDid, MethodError> {

--- a/crates/dids/src/method/mod.rs
+++ b/crates/dids/src/method/mod.rs
@@ -20,20 +20,25 @@ pub enum MethodError {
     DidCreationFailure(String),
 }
 
-/// A trait with common behavior across all DID methods.
+/// Resolve is a trait for DID methods, so that a DID Document can be resolved from a DID URI.
 pub trait Resolve {
     /// Resolve a DID URI to a [`DidResolutionResult`], as specified in
     /// [Resolving a DID](https://w3c-ccg.github.io/did-resolution/#resolving).
     fn resolve(did_uri: &str) -> impl Future<Output = ResolutionResult>;
 }
 
+/// Create is a trait for DID methods that can create DID methods. This is not enforced by the
+/// Method trait, but is a supported DID method that many methods.
 pub trait Create<O> {
+    /// Create a new DID document and return the identifier.
     fn create(
         key_manager: Arc<dyn KeyManager>,
         opts: O,
     ) -> Result<crate::bearer::BearerDid, MethodError>;
 }
 
+/// Method is the trait for DID methods overall that can be resolved. Methods can also implement
+/// the Create trait to allow for DID creation, but it is not enforced by the Method trait.
 pub trait Method<T: Resolve = Self> {
     /// The name of the implemented DID method (e.g. `jwk`).
     ///

--- a/crates/dids/src/method/mod.rs
+++ b/crates/dids/src/method/mod.rs
@@ -34,7 +34,7 @@ pub trait Create<O> {
     ) -> Result<crate::bearer::BearerDid, MethodError>;
 }
 
-pub trait Method {
+pub trait Method<T: Resolve = Self> {
     /// The name of the implemented DID method (e.g. `jwk`).
     ///
     /// This is used to identify the [`DidMethod`] responsible for creating/resolving an arbitrary

--- a/crates/dids/src/method/mod.rs
+++ b/crates/dids/src/method/mod.rs
@@ -3,8 +3,11 @@ pub mod spruce_mappers;
 pub mod web;
 
 use crate::resolver::ResolutionResult;
-use keys::{key::KeyError, key_manager::KeyManagerError};
-use std::future::Future;
+use keys::{
+    key::KeyError,
+    key_manager::{KeyManager, KeyManagerError},
+};
+use std::{future::Future, sync::Arc};
 
 /// Errors that can occur when working with DID methods.
 #[derive(thiserror::Error, Debug)]
@@ -33,4 +36,11 @@ pub trait Method {
     /// Resolve a DID URI to a [`DidResolutionResult`], as specified in
     /// [Resolving a DID](https://w3c-ccg.github.io/did-resolution/#resolving).
     fn resolve(did_uri: &str) -> impl Future<Output = ResolutionResult>;
+}
+
+pub trait Create<O> {
+    fn create(
+        key_manager: Arc<dyn KeyManager>,
+        opts: O,
+    ) -> Result<crate::bearer::BearerDid, MethodError>;
 }

--- a/crates/dids/src/method/mod.rs
+++ b/crates/dids/src/method/mod.rs
@@ -21,6 +21,19 @@ pub enum MethodError {
 }
 
 /// A trait with common behavior across all DID methods.
+pub trait Resolve {
+    /// Resolve a DID URI to a [`DidResolutionResult`], as specified in
+    /// [Resolving a DID](https://w3c-ccg.github.io/did-resolution/#resolving).
+    fn resolve(did_uri: &str) -> impl Future<Output = ResolutionResult>;
+}
+
+pub trait Create<O> {
+    fn create(
+        key_manager: Arc<dyn KeyManager>,
+        opts: O,
+    ) -> Result<crate::bearer::BearerDid, MethodError>;
+}
+
 pub trait Method {
     /// The name of the implemented DID method (e.g. `jwk`).
     ///
@@ -32,15 +45,4 @@ pub trait Method {
     /// (`jwk` in this example) is compared against each [`DidMethod`]'s `NAME` constant. If a match
     /// is found, the corresponding [`DidMethod`] is used to resolve the DID URI.
     const NAME: &'static str;
-
-    /// Resolve a DID URI to a [`DidResolutionResult`], as specified in
-    /// [Resolving a DID](https://w3c-ccg.github.io/did-resolution/#resolving).
-    fn resolve(did_uri: &str) -> impl Future<Output = ResolutionResult>;
-}
-
-pub trait Create<O> {
-    fn create(
-        key_manager: Arc<dyn KeyManager>,
-        opts: O,
-    ) -> Result<crate::bearer::BearerDid, MethodError>;
 }

--- a/crates/dids/src/method/mod.rs
+++ b/crates/dids/src/method/mod.rs
@@ -2,13 +2,9 @@ pub mod jwk;
 pub mod spruce_mappers;
 pub mod web;
 
-use crate::bearer::BearerDid;
 use crate::resolver::ResolutionResult;
-use keys::{
-    key::KeyError,
-    key_manager::{KeyManager, KeyManagerError},
-};
-use std::{future::Future, sync::Arc};
+use keys::{key::KeyError, key_manager::KeyManagerError};
+use std::future::Future;
 
 /// Errors that can occur when working with DID methods.
 #[derive(thiserror::Error, Debug)]
@@ -22,7 +18,7 @@ pub enum MethodError {
 }
 
 /// A trait with common behavior across all DID methods.
-pub trait Method<CreateOptions> {
+pub trait Method {
     /// The name of the implemented DID method (e.g. `jwk`).
     ///
     /// This is used to identify the [`DidMethod`] responsible for creating/resolving an arbitrary
@@ -33,12 +29,6 @@ pub trait Method<CreateOptions> {
     /// (`jwk` in this example) is compared against each [`DidMethod`]'s `NAME` constant. If a match
     /// is found, the corresponding [`DidMethod`] is used to resolve the DID URI.
     const NAME: &'static str;
-
-    /// Create a new DID instance.
-    fn create(
-        key_manager: Arc<dyn KeyManager>,
-        options: CreateOptions,
-    ) -> Result<BearerDid, MethodError>;
 
     /// Resolve a DID URI to a [`DidResolutionResult`], as specified in
     /// [Resolving a DID](https://w3c-ccg.github.io/did-resolution/#resolving).

--- a/crates/dids/src/method/web.rs
+++ b/crates/dids/src/method/web.rs
@@ -3,28 +3,21 @@ use crate::{
     method::{Method, MethodError, ResolutionResult},
 };
 use did_web::DIDWeb as SpruceDidWebMethod;
-use keys::key_manager::KeyManager;
 use ssi_dids::did_resolve::{DIDResolver, ResolutionInputMetadata};
-use std::sync::Arc;
 
 /// Concrete implementation for a did:web DID
 pub struct DidWeb {}
 
-/// Options that can be used to create a did:web DID.
-/// This is currently a unit struct because did:web does not support key creation.
-pub struct DidWebCreateOptions;
-
-impl Method<DidWebCreateOptions> for DidWeb {
-    const NAME: &'static str = "web";
-
-    fn create(
-        _key_manager: Arc<dyn KeyManager>,
-        _options: DidWebCreateOptions,
-    ) -> Result<BearerDid, MethodError> {
+impl DidWeb {
+    pub fn create() -> Result<BearerDid, MethodError> {
         Err(MethodError::DidCreationFailure(
             "create operation not supported for did:web".to_string(),
         ))
     }
+}
+
+impl Method for DidWeb {
+    const NAME: &'static str = "web";
 
     async fn resolve(did_uri: &str) -> ResolutionResult {
         let input_metadata = ResolutionInputMetadata::default();
@@ -45,12 +38,10 @@ impl Method<DidWebCreateOptions> for DidWeb {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use keys::key_manager::local_key_manager::LocalKeyManager;
 
     #[test]
     fn create_fails() {
-        let key_manager = Arc::new(LocalKeyManager::new_in_memory());
-        let result = DidWeb::create(key_manager, DidWebCreateOptions);
+        let result = DidWeb::create();
         assert!(result.is_err());
     }
 

--- a/crates/dids/src/method/web.rs
+++ b/crates/dids/src/method/web.rs
@@ -1,4 +1,4 @@
-use crate::method::{Method, ResolutionResult};
+use crate::method::{Method, ResolutionResult, Resolve};
 use did_web::DIDWeb as SpruceDidWebMethod;
 use ssi_dids::did_resolve::{DIDResolver, ResolutionInputMetadata};
 
@@ -7,7 +7,9 @@ pub struct DidWeb {}
 
 impl Method for DidWeb {
     const NAME: &'static str = "web";
+}
 
+impl Resolve for DidWeb {
     async fn resolve(did_uri: &str) -> ResolutionResult {
         let input_metadata = ResolutionInputMetadata::default();
         let (spruce_resolution_metadata, spruce_document, spruce_document_metadata) =

--- a/crates/dids/src/method/web.rs
+++ b/crates/dids/src/method/web.rs
@@ -1,20 +1,9 @@
-use crate::{
-    bearer::BearerDid,
-    method::{Method, MethodError, ResolutionResult},
-};
+use crate::method::{Method, ResolutionResult};
 use did_web::DIDWeb as SpruceDidWebMethod;
 use ssi_dids::did_resolve::{DIDResolver, ResolutionInputMetadata};
 
 /// Concrete implementation for a did:web DID
 pub struct DidWeb {}
-
-impl DidWeb {
-    pub fn create() -> Result<BearerDid, MethodError> {
-        Err(MethodError::DidCreationFailure(
-            "create operation not supported for did:web".to_string(),
-        ))
-    }
-}
 
 impl Method for DidWeb {
     const NAME: &'static str = "web";
@@ -38,12 +27,6 @@ impl Method for DidWeb {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn create_fails() {
-        let result = DidWeb::create();
-        assert!(result.is_err());
-    }
 
     #[tokio::test]
     async fn resolution_success() {

--- a/crates/dids/src/resolver.rs
+++ b/crates/dids/src/resolver.rs
@@ -2,7 +2,7 @@ use crate::document::Document;
 use crate::identifier::Identifier;
 use crate::method::jwk::DidJwk;
 use crate::method::web::DidWeb;
-use crate::method::Method;
+use crate::method::{Method, Resolve};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]

--- a/crates/jws/src/lib.rs
+++ b/crates/jws/src/lib.rs
@@ -152,7 +152,7 @@ mod test {
         document::VerificationMethodType,
         method::{
             jwk::{DidJwk, DidJwkCreateOptions},
-            Method,
+            Create,
         },
     };
     use keys::key_manager::local_key_manager::LocalKeyManager;

--- a/crates/jwt/src/lib.rs
+++ b/crates/jwt/src/lib.rs
@@ -94,7 +94,7 @@ mod test {
         document::VerificationMethodType,
         method::{
             jwk::{DidJwk, DidJwkCreateOptions},
-            Method,
+            Create,
         },
     };
     use jws::splice_parts;


### PR DESCRIPTION
Some DID methods allow for DID creation (e.g. with some key pair) and some have more infrastructure requirements around them (like `did:web`). This PR separates the trait for "create-able" DIDs, so that DID methods like `did:web` don't have to carry around trait types and no-implementation-implementations for trait functions they don't need.