### PR TITLE
update jwk method for creation missing verification relationships

### DIFF
--- a/crates/dids/src/method/jwk.rs
+++ b/crates/dids/src/method/jwk.rs
@@ -116,10 +116,22 @@ mod tests {
         let bearer_did = create_did_jwk();
 
         let verification_method_id = bearer_did.document.verification_method[0].id.clone();
-        assert_eq!(bearer_did.document.authentication.unwrap()[0], verification_method_id);
-        assert_eq!(bearer_did.document.assertion_method.unwrap()[0], verification_method_id);
-        assert_eq!(bearer_did.document.capability_invocation.unwrap()[0], verification_method_id);
-        assert_eq!(bearer_did.document.capability_delegation.unwrap()[0], verification_method_id);
+        assert_eq!(
+            bearer_did.document.authentication.unwrap()[0],
+            verification_method_id
+        );
+        assert_eq!(
+            bearer_did.document.assertion_method.unwrap()[0],
+            verification_method_id
+        );
+        assert_eq!(
+            bearer_did.document.capability_invocation.unwrap()[0],
+            verification_method_id
+        );
+        assert_eq!(
+            bearer_did.document.capability_delegation.unwrap()[0],
+            verification_method_id
+        );
     }
 
     #[tokio::test]
@@ -142,10 +154,22 @@ mod tests {
         assert_eq!(did_document.id, bearer_did.identifier.uri);
 
         let verification_method_id = did_document.verification_method[0].id.clone();
-        assert_eq!(did_document.authentication.unwrap()[0], verification_method_id);
-        assert_eq!(did_document.assertion_method.unwrap()[0], verification_method_id);
-        assert_eq!(did_document.capability_invocation.unwrap()[0], verification_method_id);
-        assert_eq!(did_document.capability_delegation.unwrap()[0], verification_method_id);
+        assert_eq!(
+            did_document.authentication.unwrap()[0],
+            verification_method_id
+        );
+        assert_eq!(
+            did_document.assertion_method.unwrap()[0],
+            verification_method_id
+        );
+        assert_eq!(
+            did_document.capability_invocation.unwrap()[0],
+            verification_method_id
+        );
+        assert_eq!(
+            did_document.capability_delegation.unwrap()[0],
+            verification_method_id
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
When DidJwk::create() is called, the appropriate verification relationships are missing. 

authentication, assertionMethod, capabilityInvocation and capabilityDelegation are missing and need to be set with one value equal to the verificationMethod[0].id.

closes - https://github.com/TBD54566975/web5-rs/issues/153