### PR TITLE
Update GitHub CI workflow to use Hermit dependencies #146, update Justfile cargo recipes to use entire workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ] # TODO add back windows-latest https://github.com/TBD54566975/web5-rs/issues/189
         rust: [ stable, nightly ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
-name: SDK Rust CI
+name: CI
 
 on:
   push:
     branches:
       - main
   pull_request:
-    branches:
-      - '*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,17 +12,19 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  clippy:
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [ stable, nightly ]
     steps:
-      - uses: actions/checkout@v3
-      - name: Run Clippy
-        run: cargo clippy --workspace
+      - uses: actions/checkout@v4
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+        with:
+          cache: true
+      - name: Setup
+        run: just setup
+      - name: Build
+        run: just build
   test:
-    name: cargo test
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -32,22 +32,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          cache: true
+      - name: Setup
+        run: just setup
       - name: Test
-        run: cargo test --workspace
-  format:
-    name: cargo fmt
+        run: just test
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Rustfmt
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
         with:
-          toolchain: stable
-          components: rustfmt
-      - name: Rustfmt Check
-        id: rustfmt-check
-        uses: actions-rust-lang/rustfmt@v1
+          cache: true
+      - name: Setup
+        run: just setup
+      - name: Lint
+        run: just lint

--- a/Justfile
+++ b/Justfile
@@ -8,10 +8,10 @@ setup:
   fi
 
 build: setup
-  cargo build --release
+  cargo build --workspace
 
 test: setup
-  cargo test
+  cargo test --workspace
 
 lint: setup
   cargo clippy --workspace


### PR DESCRIPTION
Closes #146 

I also edited our `build` and `test` just recipes to span the entire workspace; this way we're also ensuring that the `bindings/uniffi` project passes build & test

Also, I removed the `--release` option to the `cargo build` command to improve performance (~13% improvement in build time); the `just build` recipe is strictly for development purposes, not for building the release artifact (which will inevitably occur in the CI/CD pipeline, to be implemented at a later date)