### PR TITLE
feat: add internal did:web resolution

### DIFF
--- a/crates/web5/Cargo.toml
+++ b/crates/web5/Cargo.toml
@@ -20,6 +20,7 @@ jsonschema = { version = "0.18.0", default-features = false }
 k256 = { version = "0.13.3", features = ["ecdsa", "jwk"] }
 rand = { workspace = true }
 regex = "1.10.4"
+reqwest = { version = "0.12.4", features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }

--- a/crates/web5/src/dids/document.rs
+++ b/crates/web5/src/dids/document.rs
@@ -10,7 +10,7 @@ pub struct Document {
     pub controller: Option<Vec<String>>,
     #[serde(rename = "alsoKnownAs", skip_serializing_if = "Option::is_none")]
     pub also_known_as: Option<Vec<String>>,
-    #[serde(rename = "verificationMethod")]
+    #[serde(rename = "verificationMethod", default = "Vec::new")]
     pub verification_method: Vec<VerificationMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<Vec<String>>,

--- a/crates/web5/src/dids/identifier.rs
+++ b/crates/web5/src/dids/identifier.rs
@@ -12,7 +12,7 @@ pub enum IdentifierError {
     ParseFailure(String),
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Identifier {
     // URI represents the complete Decentralized Identifier (DID) URI.
     // Spec: https://www.w3.org/TR/did-core/#did-syntax

--- a/crates/web5/src/dids/methods/web/resolver.rs
+++ b/crates/web5/src/dids/methods/web/resolver.rs
@@ -16,7 +16,7 @@ const PORT_SEP: &str = "%3A";
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
-/// Resolver is the implementation of the did:web method for resolcing DID URIs. It is responsible
+/// Resolver is the implementation of the did:web method for resolving DID URIs. It is responsible
 /// for fetching the DID Document from the web according for the did-web spec.
 pub struct Resolver {
     did_url: String,

--- a/crates/web5/src/dids/methods/web/resolver.rs
+++ b/crates/web5/src/dids/methods/web/resolver.rs
@@ -95,5 +95,19 @@ mod tests {
         let did_uri = "did:web:tbd.website:with:path";
         let result = Resolver::new(Identifier::parse(did_uri).unwrap());
         assert_eq!(result.did_url, "https://tbd.website/with/path/did.json");
+
+        let did_uri = "did:web:tbd.website%3A8080";
+        let result = Resolver::new(Identifier::parse(did_uri).unwrap());
+        assert_eq!(
+            result.did_url,
+            "https://tbd.website:8080/.well-known/did.json"
+        );
+
+        let did_uri = "did:web:tbd.website%3A8080:with:path";
+        let result = Resolver::new(Identifier::parse(did_uri).unwrap());
+        assert_eq!(
+            result.did_url,
+            "https://tbd.website:8080/with/path/did.json"
+        );
     }
 }

--- a/crates/web5/src/dids/methods/web/resolver.rs
+++ b/crates/web5/src/dids/methods/web/resolver.rs
@@ -1,0 +1,99 @@
+use std::{
+    future::{Future, IntoFuture},
+    pin::Pin,
+};
+
+use reqwest::header::{HeaderMap, HeaderValue};
+
+use crate::dids::{
+    document::Document,
+    identifier::Identifier,
+    resolver::{ResolutionError, ResolutionResult},
+};
+
+// PORT_SEP is the : character that separates the domain from the port in a URI.
+const PORT_SEP: &str = "%3A";
+
+const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+
+/// Resolver is the implementation of the did:web method for resolcing DID URIs. It is responsible
+/// for fetching the DID Document from the web according for the did-web spec.
+pub struct Resolver {
+    did_url: String,
+}
+
+impl Resolver {
+    pub fn new(did_uri: Identifier) -> Self {
+        // note: delimited is : generally, but ; is allowed by the spec. The did-web spec (§3.2) says
+        // ; should be avoided because of it's potential use for matrix URIs.
+        let did_url = match did_uri.id.split_once(':') {
+            Some((domain, path)) => format!(
+                "{}/{}",
+                domain.replace(PORT_SEP, ":"),
+                path.split(':').collect::<Vec<&str>>().join("/"),
+            ),
+            None => format!("{}/{}", did_uri.id.replace(PORT_SEP, ":"), ".well-known",),
+        };
+
+        Self {
+            did_url: format!("https://{}/did.json", did_url),
+        }
+    }
+}
+
+// This trait implements the actual logic for resolving a DID URI to a DID Document.
+impl IntoFuture for Resolver {
+    type Output = Result<ResolutionResult, ResolutionError>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let mut headers = HeaderMap::new();
+        headers.append(
+            reqwest::header::USER_AGENT,
+            HeaderValue::from_static(USER_AGENT),
+        );
+
+        Box::pin(async move {
+            let client = reqwest::Client::builder()
+                .default_headers(headers)
+                .build()
+                .map_err(|_| ResolutionError::InternalError)?;
+
+            let response = client
+                .get(&self.did_url)
+                .send()
+                .await
+                .map_err(|_| ResolutionError::InternalError)?;
+
+            if response.status().is_success() {
+                let did_document = response
+                    .json::<Document>()
+                    .await
+                    .map_err(|_| ResolutionError::RepresentationNotSupported)?;
+
+                Ok(ResolutionResult {
+                    did_document: Some(did_document),
+                    ..Default::default()
+                })
+            } else {
+                Err(ResolutionError::NotFound)
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolution_success() {
+        let did_uri = "did:web:tbd.website";
+        let result = Resolver::new(Identifier::parse(did_uri).unwrap());
+        assert_eq!(result.did_url, "https://tbd.website/.well-known/did.json");
+
+        let did_uri = "did:web:tbd.website:with:path";
+        let result = Resolver::new(Identifier::parse(did_uri).unwrap());
+        assert_eq!(result.did_url, "https://tbd.website/with/path/did.json");
+    }
+}


### PR DESCRIPTION
Remove dependency on the Spruce crates for did:web resolution, and implement `did:web` resolution internally in the `dids` crate.

Adds a test related to #39, but needs a trusted host for a real-resolution test for a path-based DID (does TBD have one already?)

Resolves #42.

_Note_: [e830f1d](https://github.com/TBD54566975/web5-rs/pull/190/commits/e830f1dd81bdd9e9e5f4317c38b2a409977d5d47) makes the `VerificationMessage` optional to match the current set of properties in [DID-Core](https://www.w3.org/TR/did-core/#core-properties) -- the [web5-spec](https://github.com/TBD54566975/web5-spec/blob/main/spec/did.md#did-document-data-model) disagrees with this, and I'm not sure who's right -- but the example hosted DID (https://www.tbd.website/.well-known/did.json) doesn't include a `VerificationMap`. The current implementation maps this to an empty `Vec<VerificationMethod>`, this PR changes that to an `Option<Vec<VerificationMap>>`.