### PR TITLE
Fix PEX '_type' to 'r#type', add git submodule to just setup recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,6 +3,7 @@ set shell := ["bash", "-uc"]
 # Setup local development environment
 setup:
   #!/bin/bash
+  git submodule update --init --recursive
   if [[ "$(cargo 2>&1)" == *"rustup could not choose a version of cargo to run"* ]]; then
     rustup default 1.78.0
   fi

--- a/crates/credentials/src/presentation_definition.rs
+++ b/crates/credentials/src/presentation_definition.rs
@@ -203,7 +203,7 @@ impl InputDescriptor {
 
 struct JsonSchemaBuilder {
     schema: String,
-    _type: String,
+    r#type: String,
     properties: Map<String, Value>,
     required: Vec<String>,
 }
@@ -212,7 +212,7 @@ impl JsonSchemaBuilder {
     pub fn new() -> Self {
         JsonSchemaBuilder {
             schema: "http://json-schema.org/draft-07/schema#".to_string(),
-            _type: "object".to_string(),
+            r#type: "object".to_string(),
             properties: Map::new(),
             required: Vec::new(),
         }
@@ -226,7 +226,7 @@ impl JsonSchemaBuilder {
     pub fn to_json(&self) -> Value {
         json!({
             "$schema": self.schema,
-            "type": self._type,
+            "type": self.r#type,
             "properties": self.properties,
             "required": self.required,
         })


### PR DESCRIPTION
Added git submodule to `just setup` recipe so that always happens automatically -- any concern with this?