### PR TITLE
Convert dht doc to dns packet

### DIFF
--- a/crates/dids/src/methods/dht/document_packet/also_known_as.rs
+++ b/crates/dids/src/methods/dht/document_packet/also_known_as.rs
@@ -1,0 +1,45 @@
+use simple_dns::{
+    rdata::{RData, TXT},
+    Name, ResourceRecord,
+};
+
+use super::{rdata_encoder::text_from_record, DocumentPacketError, DEFAULT_TTL};
+
+pub struct AlsoKnownAs {}
+
+impl AlsoKnownAs {
+    pub fn is_aka_record(record: &ResourceRecord) -> bool {
+        match record.name.get_labels().first() {
+            None => false,
+            Some(domain) => domain.to_string() == "_aka",
+        }
+    }
+
+    pub fn to_resource_record(
+        also_known_as: &[String],
+    ) -> Result<ResourceRecord, DocumentPacketError> {
+        let name = Name::new_unchecked("_aka._did.");
+        let txt_record = TXT::new()
+            .with_string(&also_known_as.join(","))?
+            .into_owned();
+
+        Ok(ResourceRecord::new(
+            name,
+            simple_dns::CLASS::IN,
+            DEFAULT_TTL,
+            RData::TXT(txt_record),
+        ))
+    }
+
+    pub fn from_resource_record(
+        record: &ResourceRecord,
+    ) -> Result<Vec<String>, DocumentPacketError> {
+        let text = text_from_record(record)?;
+        let also_known_as = text
+            .split(',')
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        Ok(also_known_as)
+    }
+}

--- a/crates/dids/src/methods/dht/document_packet/also_known_as.rs
+++ b/crates/dids/src/methods/dht/document_packet/also_known_as.rs
@@ -43,3 +43,33 @@ impl AlsoKnownAs {
         Ok(also_known_as)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::methods::dht::document_packet::controller::Controller;
+
+    use super::*;
+
+    #[test]
+    fn test_to_and_from_resource_record() {
+        let also_known_as = vec!["Dave".to_string(), "Bartholemoop".to_string()];
+        let record = AlsoKnownAs::to_resource_record(&also_known_as)
+            .expect("expected to convert to DNS record");
+        let also_known_as2 = AlsoKnownAs::from_resource_record(&record)
+            .expect("Expected to convert from DNS record");
+        assert_eq!(also_known_as, also_known_as2);
+    }
+
+    #[test]
+    fn test_is_aka_record() {
+        let also_known_as = vec!["Dave".to_string(), "Bartholemoop".to_string()];
+        let record = AlsoKnownAs::to_resource_record(&also_known_as)
+            .expect("expected to convert to DNS record");
+
+        assert!(AlsoKnownAs::is_aka_record(&record));
+
+        let controllers = vec!["Jerb".to_string(), "Carrie Bradshaw".to_string()];
+        let record = Controller::to_resource_record(&controllers).unwrap();
+        assert!(!AlsoKnownAs::is_aka_record(&record));
+    }
+}

--- a/crates/dids/src/methods/dht/document_packet/controller.rs
+++ b/crates/dids/src/methods/dht/document_packet/controller.rs
@@ -1,0 +1,65 @@
+use simple_dns::{
+    rdata::{RData, TXT},
+    Name, ResourceRecord,
+};
+
+use super::{rdata_encoder::text_from_record, DocumentPacketError, DEFAULT_TTL};
+
+pub struct Controller {}
+
+impl Controller {
+    pub fn is_cnt_record(record: &ResourceRecord) -> bool {
+        match record.name.get_labels().first() {
+            None => false,
+            Some(domain) => domain.to_string() == "_cnt",
+        }
+    }
+
+    pub fn to_resource_record(
+        controllers: &[String],
+    ) -> Result<ResourceRecord, DocumentPacketError> {
+        let name = Name::new_unchecked("_cnt._did.");
+        let txt_record = TXT::new().with_string(&controllers.join(","))?.into_owned();
+
+        Ok(ResourceRecord::new(
+            name,
+            simple_dns::CLASS::IN,
+            DEFAULT_TTL,
+            RData::TXT(txt_record),
+        ))
+    }
+
+    pub fn from_resource_record(
+        record: &ResourceRecord,
+    ) -> Result<Vec<String>, DocumentPacketError> {
+        let text = text_from_record(record)?;
+        let controllers = text
+            .split(',')
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        Ok(controllers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_and_from_resource_record() {
+        let controllers = vec![];
+        let record = Controller::to_resource_record(&controllers)
+            .expect("Expected to create controller resource record");
+        let controllers2 = Controller::from_resource_record(&record)
+            .expect("Expected to get a list of strings from resource record");
+        assert_eq!(controllers, controllers2);
+
+        let controllers = vec!["did:dht:123".to_string(), "did:dht:456".to_string()];
+        let record = Controller::to_resource_record(&controllers)
+            .expect("Expected to create controller resource record");
+        let controllers2 = Controller::from_resource_record(&record)
+            .expect("Expected to get a list of strings from resource record");
+        assert_eq!(controllers, controllers2);
+    }
+}

--- a/crates/dids/src/methods/dht/document_packet/controller.rs
+++ b/crates/dids/src/methods/dht/document_packet/controller.rs
@@ -44,6 +44,8 @@ impl Controller {
 
 #[cfg(test)]
 mod tests {
+    use crate::methods::dht::document_packet::also_known_as::AlsoKnownAs;
+
     use super::*;
 
     #[test]
@@ -61,5 +63,18 @@ mod tests {
         let controllers2 = Controller::from_resource_record(&record)
             .expect("Expected to get a list of strings from resource record");
         assert_eq!(controllers, controllers2);
+    }
+
+    #[test]
+    fn test_is_cnt_record() {
+        let also_known_as = vec!["Dave".to_string(), "Bartholemoop".to_string()];
+        let record = Controller::to_resource_record(&also_known_as)
+            .expect("expected to convert to DNS record");
+
+        assert!(Controller::is_cnt_record(&record));
+
+        let controllers = vec!["Jerb".to_string(), "Carrie Bradshaw".to_string()];
+        let record = AlsoKnownAs::to_resource_record(&controllers).unwrap();
+        assert!(!Controller::is_cnt_record(&record));
     }
 }

--- a/crates/dids/src/methods/dht/document_packet/mod.rs
+++ b/crates/dids/src/methods/dht/document_packet/mod.rs
@@ -1,26 +1,439 @@
 use crypto::CryptoError;
 use jwk::JwkError;
 use simple_dns::SimpleDnsError;
+use std::collections::HashMap;
 
+use simple_dns::{Packet, ResourceRecord};
+
+use crate::document::{Document, Service, VerificationMethod};
+
+use self::{also_known_as::AlsoKnownAs, controller::Controller, root_record::RootRecord};
+
+mod also_known_as;
+mod controller;
 mod rdata_encoder;
-pub mod service;
-pub mod verification_method;
+mod root_record;
+mod service;
+mod verification_method;
 
 const DEFAULT_TTL: u32 = 7200; // seconds
+
+/// Convert indices from RootRecord and idx_to_vm_id map
+/// to get verification method ids for each verification relationship
+fn reconstitute_verification_relationship(
+    indices: &[u32],
+    idx_to_vm_id: &HashMap<u32, String>,
+    relationship_name: &str,
+) -> Result<Option<Vec<String>>, DocumentPacketError> {
+    let methods: Vec<String> = indices.iter()
+        .map(|idx| {
+            idx_to_vm_id.get(idx)
+                .cloned()
+                .ok_or_else(|| DocumentPacketError::RootRecord(
+                    format!("Root record contains reference to {} that is not found in verification methods", relationship_name)
+                ))
+        })
+        .collect::<Result<Vec<String>, DocumentPacketError>>()?;
+
+    let opt_methods = if methods.is_empty() {
+        None
+    } else {
+        Some(methods)
+    };
+    Ok(opt_methods)
+}
 
 /// Errors that can occur when converting between did:dht documents and DNS packets.
 #[derive(thiserror::Error, Debug)]
 pub enum DocumentPacketError {
     #[error(transparent)]
     CryptoError(#[from] CryptoError),
+    #[error("DID Document is malformed for did:dht: {0}")]
+    DocumentError(String),
     #[error(transparent)]
     Dns(#[from] SimpleDnsError),
     #[error(transparent)]
     JwkError(#[from] JwkError),
+    #[error("DNS packet was malformed: {0}")]
+    RootRecord(String),
     #[error("Could not convert between publicKeyJwk and resource record: {0}")]
     PublicKeyJwk(String),
     #[error("Could not extract fragment from DID url {0}")]
     MissingFragment(String),
     #[error("RData was invalid: {0}")]
     RDataError(String),
+}
+
+impl Document {
+    pub fn to_dns_packet(&self) -> Result<Packet, DocumentPacketError> {
+        // 0. Init root_record and empty answers array
+        let did_uri = &self.id;
+        let did_id = did_uri
+            .split(':')
+            .last()
+            .ok_or(DocumentPacketError::DocumentError(
+                "Malformed id".to_string(),
+            ))?;
+        let mut root_record = RootRecord::new(did_id);
+        let mut answers: Vec<ResourceRecord> = vec![];
+
+        // 1. Add verification methods and verification relationships to root_record and answers
+        let mut vm_id_to_idx: HashMap<String, u32> = HashMap::new();
+
+        // 1.1 Add identity key verification method
+        let identity_key_id = format!("{}#0", did_uri);
+        let id_key_vm = self
+            .verification_method
+            .iter()
+            .find(|vm| vm.id == identity_key_id);
+        match id_key_vm {
+            None => {
+                return Err(DocumentPacketError::DocumentError(
+                    "Missing identity key verification method with id #0".to_string(),
+                ))
+            }
+            Some(vm) => {
+                let idx = 0;
+
+                let vm_record = vm.to_resource_record(did_uri, idx)?.to_owned();
+                answers.push(vm_record);
+                root_record.vm.push(idx);
+                vm_id_to_idx.insert(vm.id.clone(), idx);
+            }
+        }
+
+        // 1.2 Add all other verification methods
+        let mut idx = 1;
+        self.verification_method
+            .iter()
+            .try_for_each(|vm| -> Result<(), DocumentPacketError> {
+                // skip identity key because we already added it
+                if vm.id == identity_key_id {
+                    return Ok(());
+                }
+
+                let vm_record = vm.to_resource_record(did_uri, idx)?.to_owned();
+                answers.push(vm_record);
+                root_record.vm.push(idx);
+                vm_id_to_idx.insert(vm.id.clone(), idx);
+
+                idx += 1;
+                Ok(())
+            })?;
+
+        // 2. Add verification relationships to root_record
+        // 2.1 Add assertion methods to root_record
+        if let Some(assertion_method) = &self.assertion_method {
+            assertion_method.iter().for_each(|am| {
+                if let Some(idx) = vm_id_to_idx.get(am) {
+                    root_record.asm.push(*idx)
+                }
+            });
+        }
+
+        // 2.2 Add authentication methods to root_record
+        if let Some(authentication) = &self.authentication {
+            authentication.iter().for_each(|auth| {
+                if let Some(idx) = vm_id_to_idx.get(auth) {
+                    root_record.auth.push(*idx)
+                }
+            });
+        }
+
+        // 2.3 Add capability delegations to root_record
+        if let Some(capability_delegation) = &self.capability_delegation {
+            capability_delegation.iter().for_each(|auth| {
+                if let Some(idx) = vm_id_to_idx.get(auth) {
+                    root_record.del.push(*idx)
+                }
+            });
+        }
+
+        // 2.4 Add capability invocations to root_record
+        if let Some(capability_invocation) = &self.capability_invocation {
+            capability_invocation.iter().for_each(|inv| {
+                if let Some(idx) = vm_id_to_idx.get(inv) {
+                    root_record.inv.push(*idx)
+                }
+            });
+        }
+
+        // 2.5 Add key agreements methods to root_record
+        if let Some(key_agreement) = &self.key_agreement {
+            key_agreement.iter().for_each(|agm| {
+                if let Some(idx) = vm_id_to_idx.get(agm) {
+                    root_record.agm.push(*idx)
+                }
+            });
+        }
+
+        // 3. Add service records to root_record and answers
+        if let Some(service) = &self.service {
+            service.iter().enumerate().try_for_each(
+                |(idx, src)| -> Result<(), DocumentPacketError> {
+                    let idx = idx as u32;
+                    let service_record = src.to_resource_record(idx)?;
+                    answers.push(service_record);
+                    root_record.srv.push(idx);
+
+                    Ok(())
+                },
+            )?;
+        }
+
+        // 4. Add controller to answers
+        if let Some(controllers) = &self.controller {
+            answers.push(Controller::to_resource_record(controllers)?);
+        }
+
+        // 5. Add alsoKnownAs to answers
+        if let Some(also_known_as) = &self.also_known_as {
+            answers.push(AlsoKnownAs::to_resource_record(also_known_as)?);
+        }
+
+        // 6. Create Packet from root_record and answers
+        let mut packet = Packet::new_reply(0);
+        packet
+            .answers
+            .push(root_record.to_resource_record()?.into_owned());
+        packet.answers.append(&mut answers);
+
+        Ok(packet)
+    }
+
+    pub fn from_dns_packet(packet: Packet) -> Result<Document, DocumentPacketError> {
+        let answers = &packet.answers;
+
+        // 0. Get root record
+        let root_record = answers
+            .iter()
+            .find(|record| RootRecord::is_root_record(record))
+            .ok_or(DocumentPacketError::RootRecord(
+                "Root record could not be found".to_string(),
+            ))?;
+        let root_record = RootRecord::from_resource_record(root_record)?;
+        let did_uri = format!("did:dht:{}", root_record.did_id);
+
+        // 1. Reconstitute verification methods
+        let mut idx_to_vm_id: HashMap<u32, String> = HashMap::new();
+        let mut verification_methods: Vec<VerificationMethod> = vec![];
+        for idx in &root_record.vm {
+            let record = answers
+                .iter()
+                .find(|record| VerificationMethod::is_vm_record_with_index(record, idx))
+                .ok_or(DocumentPacketError::RootRecord(
+                    "Root record contains reference to verification method record that is not found"
+                        .to_string(),
+                ))?;
+            let vm = VerificationMethod::from_resource_record(&did_uri, record, *idx == 0)?;
+            idx_to_vm_id.insert(*idx, vm.id.clone());
+            verification_methods.push(vm);
+        }
+
+        // 2. Reconstitute verification relationships
+        // 2.1 Reconstitute assertion methods
+        let assertion_method = reconstitute_verification_relationship(
+            &root_record.asm,
+            &idx_to_vm_id,
+            "assertion method",
+        )?;
+
+        // 2.2 Reconstitute authentication methods
+        let authentication = reconstitute_verification_relationship(
+            &root_record.auth,
+            &idx_to_vm_id,
+            "authentication method",
+        )?;
+
+        // 2.3 Reconstitute key agreement
+        let key_agreement = reconstitute_verification_relationship(
+            &root_record.agm,
+            &idx_to_vm_id,
+            "key agreement",
+        )?;
+
+        // 2.4 Reconstitute capability invocations
+        let capability_invocation = reconstitute_verification_relationship(
+            &root_record.inv,
+            &idx_to_vm_id,
+            "capability invocation",
+        )?;
+
+        // 2.5 Reconstitute capability delegations
+        let capability_delegation = reconstitute_verification_relationship(
+            &root_record.del,
+            &idx_to_vm_id,
+            "capability delegation",
+        )?;
+        // 3. Reconstitute services
+        let mut services: Vec<Service> = vec![];
+        for idx in root_record.srv {
+            let record = answers
+                .iter()
+                .find(|record| Service::is_service_record_with_index(record, idx))
+                .ok_or(DocumentPacketError::RootRecord(
+                    "Root record contains reference to service record that is not found"
+                        .to_string(),
+                ))?;
+
+            let service = Service::from_resource_record(&did_uri, record)?;
+            services.push(service);
+        }
+
+        let service = if services.is_empty() {
+            None
+        } else {
+            Some(services)
+        };
+
+        // 4. Reconstitute controllers
+        let controller = answers
+            .iter()
+            .find(|record| Controller::is_cnt_record(record));
+        let controller: Option<Vec<String>> = match controller {
+            None => None,
+            Some(cnt) => Some(Controller::from_resource_record(cnt)?),
+        };
+
+        // 5. Reconstitute alsoKnownAs
+        let also_known_as = answers
+            .iter()
+            .find(|record| AlsoKnownAs::is_aka_record(record));
+        let also_known_as = match also_known_as {
+            None => None,
+            Some(aka) => Some(AlsoKnownAs::from_resource_record(aka)?),
+        };
+
+        // 6. Create document
+        Ok(Document {
+            id: did_uri,
+            context: None,
+            controller,
+            also_known_as,
+            verification_method: verification_methods,
+            authentication,
+            assertion_method,
+            key_agreement,
+            capability_invocation,
+            capability_delegation,
+            service,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crypto::Curve;
+    use keys::key_manager::local_key_manager::LocalKeyManager;
+    use keys::key_manager::KeyManager;
+
+    use super::*;
+
+    fn generate_identity_key_vm(did_uri: &str) -> VerificationMethod {
+        let key_manager = Arc::new(LocalKeyManager::new());
+        let key_alias = key_manager
+            .generate_private_key(Curve::Ed25519, Some("0".to_string()))
+            .unwrap();
+        let public_key = key_manager.get_public_key(&key_alias).unwrap();
+        let public_jwk = public_key.jwk().unwrap();
+
+        VerificationMethod {
+            id: format!("{}#0", did_uri),
+            r#type: "JsonWebKey".to_string(),
+            controller: did_uri.to_string(),
+            public_key_jwk: public_jwk.clone(),
+        }
+    }
+
+    fn generate_additional_vm(did_uri: &str) -> VerificationMethod {
+        let key_manager = Arc::new(LocalKeyManager::new());
+        let key_alias = key_manager
+            .generate_private_key(Curve::Ed25519, Some("0".to_string()))
+            .unwrap();
+        let public_key = key_manager.get_public_key(&key_alias).unwrap();
+        let public_jwk = public_key.jwk().unwrap();
+
+        let thumbprint = public_jwk.compute_thumbprint().unwrap();
+
+        VerificationMethod {
+            id: format!("{}#{}", did_uri, thumbprint),
+            r#type: "JsonWebKey".to_string(),
+            controller: did_uri.to_string(),
+            public_key_jwk: public_jwk.clone(),
+        }
+    }
+
+    #[test]
+    fn test_to_and_from_packet_kitchen_sink() {
+        let did_uri = "did:dht:123";
+
+        let verification_method1 = generate_identity_key_vm(&did_uri);
+        let verification_method2 = generate_additional_vm(did_uri);
+
+        let service = Service {
+            id: "did:dht:123#foo".to_string(),
+            r#type: "bar".to_string(),
+            service_endpoint: vec!["example.com".to_string()],
+        };
+        let document = Document {
+            id: did_uri.to_string(),
+            context: None,
+            controller: Some(vec!["did:dht:345".to_string(), "did:dht:456".to_string()]),
+            also_known_as: Some(vec!["did:dht:567".to_string(), "did:dht:789".to_string()]),
+            authentication: Some(vec![
+                verification_method2.id.clone(),
+                verification_method2.id.clone(),
+            ]),
+            assertion_method: Some(vec![
+                verification_method2.id.clone(),
+                verification_method2.id.clone(),
+            ]),
+            key_agreement: Some(vec![
+                verification_method2.id.clone(),
+                verification_method2.id.clone(),
+            ]),
+            capability_invocation: Some(vec![
+                verification_method1.id.clone(),
+                verification_method2.id.clone(),
+            ]),
+            capability_delegation: Some(vec![
+                verification_method1.id.clone(),
+                verification_method2.id.clone(),
+            ]),
+            service: Some(vec![service]),
+            verification_method: vec![verification_method1, verification_method2],
+        };
+
+        let packet = document
+            .to_dns_packet()
+            .expect("expected to convert document to packet");
+
+        let document2 =
+            Document::from_dns_packet(packet).expect("expected to convert back from packet");
+
+        assert_eq!(document, document2);
+    }
+
+    #[test]
+    fn test_to_and_from_packet() {
+        let did_uri = "did:dht:123";
+
+        let verification_method = generate_identity_key_vm(&did_uri);
+        let document = Document {
+            id: did_uri.to_string(),
+            verification_method: vec![verification_method],
+            ..Default::default()
+        };
+
+        let packet = document
+            .to_dns_packet()
+            .expect("expected to convert document to packet");
+
+        let document2 =
+            Document::from_dns_packet(packet).expect("expected to convert back from packet");
+
+        assert_eq!(document, document2);
+    }
 }

--- a/crates/dids/src/methods/dht/document_packet/mod.rs
+++ b/crates/dids/src/methods/dht/document_packet/mod.rs
@@ -366,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_and_from_packet_kitchen_sink() {
+    fn test_to_and_from_packet_full_featured() {
         let did_uri = "did:dht:123";
 
         let verification_method1 = generate_identity_key_vm(&did_uri);

--- a/crates/dids/src/methods/dht/document_packet/root_record.rs
+++ b/crates/dids/src/methods/dht/document_packet/root_record.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+
+use simple_dns::{
+    rdata::{RData, TXT},
+    Name, ResourceRecord,
+};
+
+use super::{rdata_encoder::record_rdata_to_hash_map, DocumentPacketError, DEFAULT_TTL};
+
+const NAME_PREFIX: &str = "_did";
+
+#[derive(Debug, PartialEq)]
+pub struct RootRecord {
+    pub did_id: String,
+    pub vm: Vec<u32>,
+    pub srv: Vec<u32>,
+    pub inv: Vec<u32>,
+    pub del: Vec<u32>,
+    pub auth: Vec<u32>,
+    pub agm: Vec<u32>,
+    pub asm: Vec<u32>,
+}
+
+/// Parse RData value as Vec<u32> or return empty vec![] if key is absent
+fn parse_rdata_list(
+    rdata_map: &HashMap<String, String>,
+    key: &str,
+    prefix: &str,
+) -> Result<Vec<u32>, DocumentPacketError> {
+    // Step 1: Get the data string associated with the key
+    let data = match rdata_map.get(key) {
+        Some(data) => data,
+        None => return Ok(vec![]),
+    };
+
+    // Step 2: Split the data by commas and trim each part
+    let parts: Vec<&str> = data.split(',').map(|s| s.trim()).collect();
+
+    // Step 3: Strip the prefix from each part
+    let stripped_parts: Result<Vec<&str>, DocumentPacketError> = parts
+        .into_iter()
+        .map(|s| {
+            s.strip_prefix(prefix).ok_or_else(|| {
+                DocumentPacketError::RDataError(format!(
+                    "Missing prefix {} for value of {}",
+                    prefix, key
+                ))
+            })
+        })
+        .collect();
+
+    let stripped_parts = stripped_parts?;
+
+    // Step 4: Parse the stripped parts into u32
+    stripped_parts
+        .into_iter()
+        .map(|s| {
+            s.parse::<u32>().map_err(|_| {
+                DocumentPacketError::RDataError(
+                    format!("Could not parse root record entry {} into u32's", key).to_string(),
+                )
+            })
+        })
+        .collect()
+}
+
+impl RootRecord {
+    pub fn is_root_record(record: &ResourceRecord) -> bool {
+        match record.name.get_labels().first() {
+            None => false,
+            Some(subdomain) => subdomain.to_string() == NAME_PREFIX,
+        }
+    }
+
+    pub fn new(did_id: &str) -> Self {
+        RootRecord {
+            did_id: did_id.to_string(),
+            vm: Vec::new(),
+            srv: Vec::new(),
+            inv: Vec::new(),
+            del: Vec::new(),
+            auth: Vec::new(),
+            agm: Vec::new(),
+            asm: Vec::new(),
+        }
+    }
+
+    pub fn to_resource_record(&self) -> Result<ResourceRecord, DocumentPacketError> {
+        let fields = [
+            ("vm", "k", &self.vm),
+            ("asm", "k", &self.asm),
+            ("inv", "k", &self.inv),
+            ("del", "k", &self.del),
+            ("auth", "k", &self.auth),
+            ("agm", "k", &self.agm),
+            ("srv", "s", &self.srv),
+        ];
+
+        let mut parts: Vec<String> = vec![];
+        // Add each non-empty field to `parts`
+        fields.iter().for_each(|(key, prefix, vals)| {
+            if !vals.is_empty() {
+                let prefixed_vals: Vec<String> = vals
+                    .iter()
+                    .map(|idx| format!("{}{}", prefix, idx))
+                    .collect();
+                let entry = format!("{}={}", key, prefixed_vals.join(","));
+                parts.push(entry);
+            }
+        });
+        let parts = parts.join(";");
+
+        let name = Name::new_unchecked(&format!("{}.{}", NAME_PREFIX, self.did_id)).into_owned();
+        let txt_record = TXT::new().with_string(&parts)?.into_owned();
+
+        Ok(ResourceRecord::new(
+            name,
+            simple_dns::CLASS::IN,
+            DEFAULT_TTL,
+            RData::TXT(txt_record),
+        ))
+    }
+
+    pub fn from_resource_record(record: &ResourceRecord) -> Result<Self, DocumentPacketError> {
+        // todo maybe: pass did_uri as param and verify it against self.id
+
+        let labels = record.name.get_labels();
+        if labels.len() != 2 {
+            return Err(DocumentPacketError::RootRecord(
+                "Root record name must have form \"_did.<did_id>\"".to_string(),
+            ));
+        }
+        if labels[0].to_string() != "_did" {
+            return Err(DocumentPacketError::RootRecord(
+                "Root record did not have top level domain \"_did\"".to_string(),
+            ));
+        }
+        let did_id = labels[1].to_string();
+
+        let rdata_map: HashMap<String, String> = record_rdata_to_hash_map(record)?;
+
+        Ok(RootRecord {
+            did_id,
+            vm: parse_rdata_list(&rdata_map, "vm", "k")?,
+            srv: parse_rdata_list(&rdata_map, "srv", "s")?,
+            inv: parse_rdata_list(&rdata_map, "inv", "k")?,
+            del: parse_rdata_list(&rdata_map, "del", "k")?,
+            auth: parse_rdata_list(&rdata_map, "auth", "k")?,
+            agm: parse_rdata_list(&rdata_map, "agm", "k")?,
+            asm: parse_rdata_list(&rdata_map, "asm", "k")?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_and_from_resource_record_no_txt() {
+        let did_id = "123";
+        let root_record = RootRecord::new(&did_id);
+        let resource_record = root_record
+            .to_resource_record()
+            .expect("Expected to create resource record");
+        let root_record2 = RootRecord::from_resource_record(&resource_record)
+            .expect("Expected to reconstitute root record");
+        assert_eq!(root_record, root_record2);
+    }
+
+    #[test]
+    fn to_and_from_resource_record_many_values() {
+        let did_id = "123";
+        let mut root_record = RootRecord::new(&did_id);
+        root_record.vm.push(0);
+        root_record.agm.push(0);
+        root_record.asm.push(1);
+        root_record.asm.push(0);
+        root_record.auth.push(0);
+        root_record.del.push(0);
+        root_record.del.push(2);
+        root_record.inv.push(0);
+        root_record.srv.push(0);
+        root_record.srv.push(10);
+
+        let resource_record = root_record
+            .to_resource_record()
+            .expect("Expected to create resource record");
+        let root_record2 = RootRecord::from_resource_record(&resource_record)
+            .expect("Expected to reconstitute root record");
+        assert_eq!(root_record, root_record2);
+    }
+}


### PR DESCRIPTION
The last step in converting between did:dht documents and DNS packets. This includes:
1. Converting verification methods and verification relationships to and from DNS records and references thereof within the root record.
2. Converting services to and from DNS records and references references thereof within the root record
3. Converting alsoKnownAs to and from DNS records
4. Converting Controllers to and from DNS records

Possibly in follow up PR: More test coverage for `Document::to_packet` and `Document::from_packet` for unhappy paths.