### PR TITLE
fix: disable jsonschema resolution to support web5-rs in WASM builds

### DIFF
--- a/crates/web5/Cargo.toml
+++ b/crates/web5/Cargo.toml
@@ -16,7 +16,7 @@ ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 getrandom = { version = "0.2.12", features = ["js"] }
 hex = "0.4"
 jsonpath-rust = "0.5.1"
-jsonschema = "0.17.1"
+jsonschema = { version = "0.18.0", default-features = false }
 k256 = { version = "0.13.3", features = ["ecdsa", "jwk"] }
 rand = { workspace = true }
 regex = "1.10.4"


### PR DESCRIPTION
Without disabling the resolve-http feature, the jsonschema crate fails to build on WASM environments due to use of `reqwest::blocking`, which is not built in WASM environments. Stranger6667/jsonschema-rs#222 has additional context.

The use of jsonschema, currently at least, does not use resolution and is used against a schema defined in code for Verifiable Credentials. 