### PR TITLE
Add APID VC implementations for sign & verify, add JSON serialization for VC at UniFFI layer

### DIFF
--- a/bindings/web5_uniffi/src/lib.rs
+++ b/bindings/web5_uniffi/src/lib.rs
@@ -1,7 +1,9 @@
 use web5_uniffi_wrapper::{
     credentials::{
         presentation_definition::PresentationDefinition,
-        verifiable_credential_1_1::VerifiableCredential,
+        verifiable_credential_1_1::{
+            data::VerifiableCredential as VerifiableCredentialData, VerifiableCredential,
+        },
     },
     crypto::{in_memory_key_manager::InMemoryKeyManager, key_manager::KeyManager},
     dids::{
@@ -23,16 +25,10 @@ use web5_uniffi_wrapper::{
 };
 
 use web5::apid::{
-    credentials::{
-        presentation_definition::{
-            Constraints as ConstraintsData, Field as FieldData, Filter as FilterData,
-            InputDescriptor as InputDescriptorData, Optionality,
-            PresentationDefinition as PresentationDefinitionData,
-        },
-        verifiable_credential_1_1::{
-            CredentialSubject as CredentialSubjectData,
-            VerifiableCredential as VerifiableCredentialData,
-        },
+    credentials::presentation_definition::{
+        Constraints as ConstraintsData, Field as FieldData, Filter as FilterData,
+        InputDescriptor as InputDescriptorData, Optionality,
+        PresentationDefinition as PresentationDefinitionData,
     },
     crypto::jwk::Jwk as JwkData,
     dids::{

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -213,8 +213,8 @@ dictionary VerifiableCredentialData {
   string id;
   sequence<string> type;
   string issuer;
-  string issuance_date;
-  string? expiration_date;
+  timestamp issuance_date;
+  timestamp? expiration_date;
   string credential_subject;
 };
 

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -212,10 +212,10 @@ dictionary VerifiableCredentialData {
   sequence<string> context;
   string id;
   sequence<string> type;
-  string issuer;
+  string json_serialized_issuer;
   timestamp issuance_date;
   timestamp? expiration_date;
-  string credential_subject;
+  string json_serialized_credential_subject;
 };
 
 interface VerifiableCredential {

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -208,11 +208,6 @@ interface BearerDid {
   Signer get_signer(string key_id);
 };
 
-dictionary CredentialSubjectData {
-  string id;
-  record<string, string>? params;
-};
-
 dictionary VerifiableCredentialData {
   sequence<string> context;
   string id;
@@ -220,10 +215,11 @@ dictionary VerifiableCredentialData {
   string issuer;
   string issuance_date;
   string? expiration_date;
-  CredentialSubjectData credential_subject;
+  string credential_subject;
 };
 
 interface VerifiableCredential {
+  [Throws=RustCoreError]
   constructor(VerifiableCredentialData data);
   [Name=verify, Throws=RustCoreError]
   constructor([ByRef] string vcjwt);
@@ -233,6 +229,7 @@ interface VerifiableCredential {
   string sign(BearerDid bearer_did);
   [Throws=RustCoreError]
   string sign_with_signer([ByRef] string key_id, Signer signer);
+  [Throws=RustCoreError]
   VerifiableCredentialData get_data();
 };
 

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -230,7 +230,9 @@ interface VerifiableCredential {
   [Name=verify_with_verifier, Throws=RustCoreError]
   constructor([ByRef] string vcjwt, Verifier verifier);
   [Throws=RustCoreError]
-  string sign(Signer signer);
+  string sign(BearerDid bearer_did);
+  [Throws=RustCoreError]
+  string sign_with_signer([ByRef] string key_id, Signer signer);
   VerifiableCredentialData get_data();
 };
 

--- a/bindings/web5_uniffi_wrapper/Cargo.toml
+++ b/bindings/web5_uniffi_wrapper/Cargo.toml
@@ -7,5 +7,6 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 web5 = { path = "../../crates/web5" }

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
@@ -1,40 +1,109 @@
 use crate::{
     dids::bearer_did::BearerDid,
     dsa::{Signer, Verifier},
-    errors::Result,
+    errors::{Result, RustCoreError},
 };
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use web5::apid::credentials::verifiable_credential_1_1::VerifiableCredential as InnerVerifiableCredential;
 
-pub struct VerifiableCredential(pub InnerVerifiableCredential);
+pub struct VerifiableCredential(pub Arc<RwLock<InnerVerifiableCredential>>);
 
 impl VerifiableCredential {
-    pub fn new(verifiable_credential: InnerVerifiableCredential) -> Self {
-        Self(verifiable_credential)
+    pub fn new(verifiable_credential: data::VerifiableCredential) -> Result<Self> {
+        let inner_verifiable_credential = verifiable_credential.to_inner()?;
+
+        Ok(Self(Arc::new(RwLock::new(inner_verifiable_credential))))
     }
 
     pub fn verify(vcjwt: &str) -> Result<Self> {
-        let vc = InnerVerifiableCredential::verify(vcjwt).map_err(|e| Arc::new(e.into()))?;
-        Ok(Self(vc))
+        let inner_verifiable_credential =
+            InnerVerifiableCredential::verify(vcjwt).map_err(|e| Arc::new(e.into()))?;
+
+        Ok(Self(Arc::new(RwLock::new(inner_verifiable_credential))))
     }
 
     pub fn verify_with_verifier(vcjwt: &str, verifier: Arc<dyn Verifier>) -> Result<Self> {
-        let vc = InnerVerifiableCredential::verify_with_verifier(vcjwt, verifier.to_inner())
-            .map_err(|e| Arc::new(e.into()))?;
-        Ok(Self(vc))
+        let inner_verifiable_credential =
+            InnerVerifiableCredential::verify_with_verifier(vcjwt, verifier.to_inner())
+                .map_err(|e| Arc::new(e.into()))?;
+
+        Ok(Self(Arc::new(RwLock::new(inner_verifiable_credential))))
     }
 
     pub fn sign(&self, bearer_did: Arc<BearerDid>) -> Result<String> {
-        self.0.sign(&bearer_did.0).map_err(|e| Arc::new(e.into()))
+        let inner_verifiable_credential = self
+            .0
+            .read()
+            .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
+        inner_verifiable_credential
+            .sign(&bearer_did.0)
+            .map_err(|e| Arc::new(e.into()))
     }
 
     pub fn sign_with_signer(&self, key_id: &str, signer: Arc<dyn Signer>) -> Result<String> {
-        self.0
+        let inner_verifiable_credential = self
+            .0
+            .read()
+            .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
+        inner_verifiable_credential
             .sign_with_signer(key_id, signer.to_inner())
             .map_err(|e| Arc::new(e.into()))
     }
 
-    pub fn get_data(&self) -> InnerVerifiableCredential {
-        self.0.clone()
+    pub fn get_data(&self) -> Result<data::VerifiableCredential> {
+        let inner_verifiable_credential = self
+            .0
+            .read()
+            .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
+        data::VerifiableCredential::from_inner(inner_verifiable_credential.clone())
+    }
+}
+
+pub mod data {
+    use super::*;
+
+    #[derive(Clone)]
+    pub struct VerifiableCredential {
+        pub context: Vec<String>,
+        pub id: String,
+        pub r#type: Vec<String>,
+        pub issuer: String, // JSON serialized
+        pub issuance_date: String,
+        pub expiration_date: Option<String>,
+        pub credential_subject: String, // JSON serialized
+    }
+
+    impl VerifiableCredential {
+        pub fn from_inner(inner_verifiable_credential: InnerVerifiableCredential) -> Result<Self> {
+            Ok(Self {
+                context: inner_verifiable_credential.context.clone(),
+                id: inner_verifiable_credential.id.clone(),
+                r#type: inner_verifiable_credential.r#type.clone(),
+                issuer: serde_json::to_string(&inner_verifiable_credential.issuer)
+                    .map_err(|e| Arc::new(e.into()))?,
+                issuance_date: inner_verifiable_credential.issuance_date.clone(),
+                expiration_date: inner_verifiable_credential.expiration_date.clone(),
+                credential_subject: serde_json::to_string(
+                    &inner_verifiable_credential.credential_subject,
+                )
+                .map_err(|e| Arc::new(e.into()))?,
+            })
+        }
+
+        pub fn to_inner(&self) -> Result<InnerVerifiableCredential> {
+            Ok(InnerVerifiableCredential {
+                context: self.context.clone(),
+                id: self.id.clone(),
+                r#type: self.r#type.clone(),
+                issuer: serde_json::from_str(&self.issuer).map_err(|e| Arc::new(e.into()))?,
+                issuance_date: self.issuance_date.clone(),
+                expiration_date: self.expiration_date.clone(),
+                credential_subject: serde_json::from_str(&self.credential_subject)
+                    .map_err(|e| Arc::new(e.into()))?,
+            })
+        }
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
@@ -1,4 +1,5 @@
 use crate::{
+    dids::bearer_did::BearerDid,
     dsa::{Signer, Verifier},
     errors::Result,
 };
@@ -23,9 +24,13 @@ impl VerifiableCredential {
         Ok(Self(vc))
     }
 
-    pub fn sign(&self, signer: Arc<dyn Signer>) -> Result<String> {
+    pub fn sign(&self, bearer_did: Arc<BearerDid>) -> Result<String> {
+        self.0.sign(&bearer_did.0).map_err(|e| Arc::new(e.into()))
+    }
+
+    pub fn sign_with_signer(&self, key_id: &str, signer: Arc<dyn Signer>) -> Result<String> {
         self.0
-            .sign(signer.to_inner())
+            .sign_with_signer(key_id, signer.to_inner())
             .map_err(|e| Arc::new(e.into()))
     }
 

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
@@ -99,7 +99,8 @@ pub mod data {
                 context: self.context.clone(),
                 id: self.id.clone(),
                 r#type: self.r#type.clone(),
-                issuer: serde_json::from_str(&self.json_serialized_issuer).map_err(|e| Arc::new(e.into()))?,
+                issuer: serde_json::from_str(&self.json_serialized_issuer)
+                    .map_err(|e| Arc::new(e.into()))?,
                 issuance_date: self.issuance_date,
                 expiration_date: self.expiration_date,
                 credential_subject: serde_json::from_str(&self.json_serialized_credential_subject)

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
@@ -71,10 +71,10 @@ pub mod data {
         pub context: Vec<String>,
         pub id: String,
         pub r#type: Vec<String>,
-        pub issuer: String, // JSON serialized
+        pub json_serialized_issuer: String, // JSON serialized
         pub issuance_date: SystemTime,
         pub expiration_date: Option<SystemTime>,
-        pub credential_subject: String, // JSON serialized
+        pub json_serialized_credential_subject: String, // JSON serialized
     }
 
     impl VerifiableCredential {
@@ -83,11 +83,11 @@ pub mod data {
                 context: inner_verifiable_credential.context.clone(),
                 id: inner_verifiable_credential.id.clone(),
                 r#type: inner_verifiable_credential.r#type.clone(),
-                issuer: serde_json::to_string(&inner_verifiable_credential.issuer)
+                json_serialized_issuer: serde_json::to_string(&inner_verifiable_credential.issuer)
                     .map_err(|e| Arc::new(e.into()))?,
                 issuance_date: inner_verifiable_credential.issuance_date,
                 expiration_date: inner_verifiable_credential.expiration_date,
-                credential_subject: serde_json::to_string(
+                json_serialized_credential_subject: serde_json::to_string(
                     &inner_verifiable_credential.credential_subject,
                 )
                 .map_err(|e| Arc::new(e.into()))?,
@@ -99,10 +99,10 @@ pub mod data {
                 context: self.context.clone(),
                 id: self.id.clone(),
                 r#type: self.r#type.clone(),
-                issuer: serde_json::from_str(&self.issuer).map_err(|e| Arc::new(e.into()))?,
+                issuer: serde_json::from_str(&self.json_serialized_issuer).map_err(|e| Arc::new(e.into()))?,
                 issuance_date: self.issuance_date,
                 expiration_date: self.expiration_date,
-                credential_subject: serde_json::from_str(&self.credential_subject)
+                credential_subject: serde_json::from_str(&self.json_serialized_credential_subject)
                     .map_err(|e| Arc::new(e.into()))?,
             })
         }

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_credential_1_1.rs
@@ -64,6 +64,7 @@ impl VerifiableCredential {
 
 pub mod data {
     use super::*;
+    use std::time::SystemTime;
 
     #[derive(Clone)]
     pub struct VerifiableCredential {
@@ -71,8 +72,8 @@ pub mod data {
         pub id: String,
         pub r#type: Vec<String>,
         pub issuer: String, // JSON serialized
-        pub issuance_date: String,
-        pub expiration_date: Option<String>,
+        pub issuance_date: SystemTime,
+        pub expiration_date: Option<SystemTime>,
         pub credential_subject: String, // JSON serialized
     }
 
@@ -84,8 +85,8 @@ pub mod data {
                 r#type: inner_verifiable_credential.r#type.clone(),
                 issuer: serde_json::to_string(&inner_verifiable_credential.issuer)
                     .map_err(|e| Arc::new(e.into()))?,
-                issuance_date: inner_verifiable_credential.issuance_date.clone(),
-                expiration_date: inner_verifiable_credential.expiration_date.clone(),
+                issuance_date: inner_verifiable_credential.issuance_date,
+                expiration_date: inner_verifiable_credential.expiration_date,
                 credential_subject: serde_json::to_string(
                     &inner_verifiable_credential.credential_subject,
                 )
@@ -99,8 +100,8 @@ pub mod data {
                 id: self.id.clone(),
                 r#type: self.r#type.clone(),
                 issuer: serde_json::from_str(&self.issuer).map_err(|e| Arc::new(e.into()))?,
-                issuance_date: self.issuance_date.clone(),
-                expiration_date: self.expiration_date.clone(),
+                issuance_date: self.issuance_date,
+                expiration_date: self.expiration_date,
                 credential_subject: serde_json::from_str(&self.credential_subject)
                     .map_err(|e| Arc::new(e.into()))?,
             })

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use serde_json::Error as SerdeJsonError;
+use std::sync::{Arc, PoisonError};
 use std::{any::type_name, fmt::Debug};
 use thiserror::Error;
 use web5::apid::credentials::presentation_definition::PexError;
@@ -21,6 +22,14 @@ pub enum RustCoreError {
 }
 
 impl RustCoreError {
+    pub fn from_poison_error<T>(error: PoisonError<T>, error_type: &str) -> Arc<Self> {
+        Arc::new(RustCoreError::Error {
+            r#type: error_type.to_string(),
+            variant: "PoisonError".to_string(),
+            message: error.to_string(),
+        })
+    }
+
     fn new<T>(error: T) -> Self
     where
         T: std::error::Error + 'static,
@@ -119,6 +128,12 @@ impl From<DidDataModelError> for RustCoreError {
 
 impl From<BearerDidError> for RustCoreError {
     fn from(error: BearerDidError) -> Self {
+        RustCoreError::new(error)
+    }
+}
+
+impl From<SerdeJsonError> for RustCoreError {
+    fn from(error: SerdeJsonError) -> Self {
         RustCoreError::new(error)
     }
 }

--- a/crates/web5/Cargo.toml
+++ b/crates/web5/Cargo.toml
@@ -15,6 +15,7 @@ did-web = "0.2.2"
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 getrandom = { version = "0.2.12", features = ["js"] }
 hex = "0.4"
+josekit = "0.8.6"
 jsonpath-rust = "0.5.1"
 jsonschema = { version = "0.18.0", default-features = false }
 k256 = { version = "0.13.3", features = ["ecdsa", "jwk"] }

--- a/crates/web5/src/apid/credentials/mod.rs
+++ b/crates/web5/src/apid/credentials/mod.rs
@@ -2,7 +2,8 @@ use josekit::JoseError as JosekitError;
 use serde_json::Error as SerdeJsonError;
 
 use super::dids::{
-    bearer_did::BearerDidError, data_model::DataModelError, did::DidError, resolution::resolution_metadata::ResolutionMetadataError
+    bearer_did::BearerDidError, data_model::DataModelError, did::DidError,
+    resolution::resolution_metadata::ResolutionMetadataError,
 };
 
 pub mod presentation_definition;

--- a/crates/web5/src/apid/credentials/mod.rs
+++ b/crates/web5/src/apid/credentials/mod.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTimeError;
+
 use josekit::JoseError as JosekitError;
 use serde_json::Error as SerdeJsonError;
 
@@ -37,6 +39,8 @@ pub enum CredentialError {
     DidDataModel(#[from] DataModelError),
     #[error(transparent)]
     Did(#[from] DidError),
+    #[error(transparent)]
+    SystemTime(#[from] SystemTimeError),
 }
 
 impl From<SerdeJsonError> for CredentialError {

--- a/crates/web5/src/apid/credentials/mod.rs
+++ b/crates/web5/src/apid/credentials/mod.rs
@@ -1,3 +1,10 @@
+use josekit::JoseError as JosekitError;
+use serde_json::Error as SerdeJsonError;
+
+use super::dids::{
+    bearer_did::BearerDidError, data_model::DataModelError, did::DidError, resolution::resolution_metadata::ResolutionMetadataError
+};
+
 pub mod presentation_definition;
 pub mod verifiable_credential_1_1;
 
@@ -15,6 +22,26 @@ pub enum CredentialError {
     VcDataModelValidationError(String),
     #[error("invalid timestamp: {0}")]
     InvalidTimestamp(String),
+    #[error("serde json error {0}")]
+    SerdeJsonError(String),
+    #[error(transparent)]
+    Jose(#[from] JosekitError),
+    #[error(transparent)]
+    BearerDid(#[from] BearerDidError),
+    #[error("missing kid jose header")]
+    MissingKid,
+    #[error(transparent)]
+    Resolution(#[from] ResolutionMetadataError),
+    #[error(transparent)]
+    DidDataModel(#[from] DataModelError),
+    #[error(transparent)]
+    Did(#[from] DidError),
+}
+
+impl From<SerdeJsonError> for CredentialError {
+    fn from(err: SerdeJsonError) -> Self {
+        CredentialError::SerdeJsonError(err.to_string())
+    }
 }
 
 type Result<T> = std::result::Result<T, CredentialError>;

--- a/crates/web5/src/apid/credentials/verifiable_credential_1_1.rs
+++ b/crates/web5/src/apid/credentials/verifiable_credential_1_1.rs
@@ -291,8 +291,6 @@ impl VerifiableCredential {
             }
         }
 
-        // TODO prioritize JWT claims -- hit up Neal
-
         validate_vc_data_model(&vc)?;
 
         Ok(vc)

--- a/crates/web5/src/apid/credentials/verifiable_credential_1_1.rs
+++ b/crates/web5/src/apid/credentials/verifiable_credential_1_1.rs
@@ -9,7 +9,7 @@ use crate::apid::{
     },
     dsa::{ed25519::Ed25519Verifier, DsaError, Signer, Verifier},
 };
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use core::fmt;
 use josekit::{
     jws::{
@@ -429,14 +429,6 @@ impl core::fmt::Debug for JoseVerifier {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Verifier").field("kid", &self.kid).finish()
     }
-}
-
-pub fn timestamp_to_rfc3339(timestamp: i64) -> Result<String> {
-    let datetime = Utc
-        .timestamp_opt(timestamp, 0)
-        .single()
-        .ok_or_else(|| CredentialError::InvalidTimestamp("Invalid timestamp".to_string()))?;
-    Ok(datetime.to_rfc3339())
 }
 
 #[cfg(test)]

--- a/crates/web5/src/apid/dids/data_model/document.rs
+++ b/crates/web5/src/apid/dids/data_model/document.rs
@@ -40,6 +40,6 @@ impl Document {
                 return Ok(vm.public_key_jwk.clone());
             }
         }
-        Err(super::DataModelError::PublicKeyJwk(key_id))
+        Err(super::DataModelError::MissingPublicKeyJwk(key_id))
     }
 }

--- a/crates/web5/src/apid/dids/data_model/mod.rs
+++ b/crates/web5/src/apid/dids/data_model/mod.rs
@@ -5,7 +5,7 @@ pub mod verification_method;
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum DataModelError {
     #[error("publicKeyJwk not found {0}")]
-    PublicKeyJwk(String),
+    MissingPublicKeyJwk(String),
 }
 
 type Result<T> = std::result::Result<T, DataModelError>;


### PR DESCRIPTION
- Implement VC sign & verify within `apid` module
    - [Updated APID](https://github.com/TBD54566975/web5-rs/commit/e7f82faf7870daa1bfbad16396ec9de00374d81b) to include `sign(bearer_did: BearerDid` method
- Change VC datetime types from `String` to `SystemTime`
- Add JSON serialization for VC `issuer` and `credentialSubject` at the UniFFI layer