### PR TITLE
Add foreign trait implementation support

### DIFF
--- a/bindings/web5_uniffi/src/lib.rs
+++ b/bindings/web5_uniffi/src/lib.rs
@@ -22,6 +22,7 @@ use web5_uniffi_wrapper::{
             did_jwk::{did_jwk_resolve, DidJwk},
             did_web::{did_web_resolve, DidWeb},
         },
+        portable_did::PortableDid,
         resolution::resolution_result::ResolutionResult,
     },
     errors::RustCoreError,
@@ -39,6 +40,7 @@ use web5::{
             did_dht::DidDht as DidDhtData, did_jwk::DidJwk as DidJwkData,
             did_web::DidWeb as DidWebData,
         },
+        portable_did::PortableDid as PortableDidData,
         resolution::{
             document_metadata::DocumentMetadata as DocumentMetadataData,
             resolution_metadata::{

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -193,6 +193,18 @@ interface DidDht {
   DidDhtData get_data();
 };
 
+dictionary PortableDidData {
+  string did_uri;
+  DocumentData document;
+  sequence<JwkData> private_jwks;
+};
+
+interface PortableDid {
+  [Throws=RustCoreError]
+  constructor([ByRef] string json);
+  PortableDidData get_data();
+};
+
 dictionary BearerDidData {
   DidData did;
   DocumentData document;
@@ -202,6 +214,8 @@ dictionary BearerDidData {
 interface BearerDid {
   [Throws=RustCoreError]
   constructor([ByRef] string uri, KeyManager key_manager);
+  [Throws=RustCoreError, Name=from_portable_did]
+  constructor(PortableDid portable_did);
   BearerDidData get_data();
   [Throws=RustCoreError]
   Signer get_signer(string key_id);

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -8,10 +8,9 @@ namespace web5 {
   ResolutionResult did_dht_resolve([ByRef] string uri);
 };
 
+[Error]
 interface RustCoreError {
-  string error_type();
-  string variant();
-  string message();
+  Error(string type, string variant, string msg);
 };
 
 dictionary JwkData {
@@ -23,7 +22,7 @@ dictionary JwkData {
   string? y;
 };
 
-[Trait]
+[Trait, WithForeign]
 interface KeyManager {
   [Throws=RustCoreError]
   Signer get_signer(JwkData public_jwk);
@@ -42,28 +41,28 @@ enum Dsa {
   "Ed25519"
 };
 
-[Trait]
+[Trait, WithForeign]
 interface Signer {
   [Throws=RustCoreError]
-  bytes sign([ByRef] sequence<u8> payload);
+  bytes sign(bytes payload);
 };
 
-[Trait]
+[Trait, WithForeign]
 interface Verifier {
   [Throws=RustCoreError]
-  boolean verify([ByRef] sequence<u8> message, [ByRef] sequence<u8> signature);
+  boolean verify(bytes message, bytes signature);
 };
 
 interface Ed25519Signer {
   constructor(JwkData private_key);
   [Throws=RustCoreError]
-  bytes sign([ByRef] sequence<u8> payload);
+  bytes sign(bytes payload);
 };
 
 interface Ed25519Verifier {
   constructor(JwkData public_jwk);
   [Throws=RustCoreError]
-  boolean verify([ByRef] sequence<u8> message, [ByRef] sequence<u8> signature);
+  boolean verify(bytes message, bytes signature);
 };
 
 dictionary DidData {

--- a/bindings/web5_uniffi_wrapper/src/credentials/presentation_definition.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/presentation_definition.rs
@@ -1,5 +1,4 @@
 use crate::errors::Result;
-use std::sync::Arc;
 use web5::credentials::presentation_definition::PresentationDefinition as InnerPresentationDefinition;
 
 pub struct PresentationDefinition(pub InnerPresentationDefinition);
@@ -8,21 +7,17 @@ impl PresentationDefinition {
     pub fn new(json_serialized_presentation_definition: String) -> Result<Self> {
         let inner_presentation_definition = serde_json::from_str::<InnerPresentationDefinition>(
             &json_serialized_presentation_definition,
-        )
-        .map_err(|e| Arc::new(e.into()))?;
+        )?;
 
         Ok(Self(inner_presentation_definition))
     }
 
     pub fn select_credentials(&self, vc_jwts: &Vec<String>) -> Result<Vec<String>> {
-        self.0
-            .select_credentials(vc_jwts)
-            .map_err(|e| Arc::new(e.into()))
+        Ok(self.0.select_credentials(vc_jwts)?)
     }
 
     pub fn get_json_serialized_presentation_definition(&self) -> Result<String> {
-        let json_serialized_presentation_definition =
-            serde_json::to_string(&self.0).map_err(|e| Arc::new(e.into()))?;
+        let json_serialized_presentation_definition = serde_json::to_string(&self.0)?;
 
         Ok(json_serialized_presentation_definition)
     }

--- a/bindings/web5_uniffi_wrapper/src/crypto/dsa/ed25519.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/dsa/ed25519.rs
@@ -1,6 +1,5 @@
 use super::{Signer, Verifier};
 use crate::errors::Result;
-use std::sync::Arc;
 use web5::crypto::{
     dsa::{
         ed25519::{
@@ -25,12 +24,8 @@ impl Ed25519Signer {
 }
 
 impl Signer for Ed25519Signer {
-    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        self.0.sign(payload).map_err(|e| Arc::new(e.into()))
-    }
-
-    fn to_inner(&self) -> Arc<dyn InnerSigner> {
-        Arc::new(self.0.clone())
+    fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>> {
+        Ok(self.0.sign(&payload)?)
     }
 }
 
@@ -43,13 +38,7 @@ impl Ed25519Verifier {
 }
 
 impl Verifier for Ed25519Verifier {
-    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<bool> {
-        self.0
-            .verify(payload, signature)
-            .map_err(|e| Arc::new(e.into()))
-    }
-
-    fn to_inner(&self) -> Arc<dyn InnerVerifier> {
-        Arc::new(self.0.clone())
+    fn verify(&self, payload: Vec<u8>, signature: Vec<u8>) -> Result<bool> {
+        Ok(self.0.verify(&payload, &signature)?)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/crypto/dsa/mod.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/dsa/mod.rs
@@ -5,23 +5,38 @@ use std::sync::Arc;
 use web5::crypto::dsa::{Signer as InnerSigner, Verifier as InnerVerifier};
 
 pub trait Signer: Send + Sync {
-    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>>;
-    fn to_inner(&self) -> Arc<dyn InnerSigner>;
+    fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>>;
 }
 
-pub struct OuterSigner(pub Arc<dyn InnerSigner>);
+pub struct ToOuterSigner(pub Arc<dyn InnerSigner>);
 
-impl Signer for OuterSigner {
-    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        self.0.sign(payload).map_err(|e| Arc::new(e.into()))
+impl Signer for ToOuterSigner {
+    fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>> {
+        Ok(self.0.sign(&payload)?)
     }
+}
 
-    fn to_inner(&self) -> Arc<dyn InnerSigner> {
-        self.0.clone()
+pub struct ToInnerSigner(pub Arc<dyn Signer>);
+
+impl InnerSigner for ToInnerSigner {
+    fn sign(&self, payload: &[u8]) -> web5::crypto::dsa::Result<Vec<u8>> {
+        let signature = self.0.sign(Vec::from(payload)).unwrap(); // 🚧 unwrap, need a .into() I think
+        Ok(signature)
     }
 }
 
 pub trait Verifier: Send + Sync {
-    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<bool>;
-    fn to_inner(&self) -> Arc<dyn InnerVerifier>;
+    fn verify(&self, payload: Vec<u8>, signature: Vec<u8>) -> Result<bool>;
+}
+
+pub struct ToInnerVerifier(pub Arc<dyn Verifier>);
+
+impl InnerVerifier for ToInnerVerifier {
+    fn verify(&self, payload: &[u8], signature: &[u8]) -> web5::crypto::dsa::Result<bool> {
+        let verified = self
+            .0
+            .verify(Vec::from(payload), Vec::from(signature))
+            .unwrap(); // 🚧 unwrap, need a .into() I think
+        Ok(verified)
+    }
 }

--- a/bindings/web5_uniffi_wrapper/src/crypto/dsa/mod.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/dsa/mod.rs
@@ -20,7 +20,7 @@ pub struct ToInnerSigner(pub Arc<dyn Signer>);
 
 impl InnerSigner for ToInnerSigner {
     fn sign(&self, payload: &[u8]) -> web5::crypto::dsa::Result<Vec<u8>> {
-        let signature = self.0.sign(Vec::from(payload)).unwrap(); // 🚧 unwrap, need a .into() I think
+        let signature = self.0.sign(Vec::from(payload))?;
         Ok(signature)
     }
 }
@@ -33,10 +33,7 @@ pub struct ToInnerVerifier(pub Arc<dyn Verifier>);
 
 impl InnerVerifier for ToInnerVerifier {
     fn verify(&self, payload: &[u8], signature: &[u8]) -> web5::crypto::dsa::Result<bool> {
-        let verified = self
-            .0
-            .verify(Vec::from(payload), Vec::from(signature))
-            .unwrap(); // 🚧 unwrap, need a .into() I think
+        let verified = self.0.verify(Vec::from(payload), Vec::from(signature))?;
         Ok(verified)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/crypto/in_memory_key_manager.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/in_memory_key_manager.rs
@@ -1,5 +1,5 @@
 use super::{
-    dsa::{OuterSigner, Signer},
+    dsa::{Signer, ToOuterSigner},
     key_manager::KeyManager,
 };
 use crate::errors::Result;
@@ -21,9 +21,7 @@ impl InMemoryKeyManager {
     }
 
     pub fn import_private_jwk(&self, private_key: Jwk) -> Result<Jwk> {
-        self.0
-            .import_private_jwk(private_key)
-            .map_err(|e| Arc::new(e.into()))
+        Ok(self.0.import_private_jwk(private_key)?)
     }
 
     pub fn get_as_key_manager(&self) -> Arc<dyn KeyManager> {
@@ -33,16 +31,9 @@ impl InMemoryKeyManager {
 
 impl KeyManager for InMemoryKeyManager {
     fn get_signer(&self, public_jwk: Jwk) -> Result<Arc<dyn Signer>> {
-        let signer = self
-            .0
-            .get_signer(public_jwk)
-            .map_err(|e| Arc::new(e.into()))?;
-        let outer_signer = OuterSigner(signer);
+        let signer = self.0.get_signer(public_jwk)?;
+        let outer_signer = ToOuterSigner(signer);
         Ok(Arc::new(outer_signer))
-    }
-
-    fn to_inner(&self) -> Arc<dyn InnerKeyManager> {
-        Arc::new(self.0.clone())
     }
 }
 

--- a/bindings/web5_uniffi_wrapper/src/crypto/key_manager.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/key_manager.rs
@@ -1,4 +1,4 @@
-use super::dsa::{ToOuterSigner, Signer, ToInnerSigner};
+use super::dsa::{Signer, ToInnerSigner, ToOuterSigner};
 use crate::errors::Result;
 use std::sync::Arc;
 use web5::crypto::{jwk::Jwk, key_managers::key_manager::KeyManager as InnerKeyManager};
@@ -24,7 +24,7 @@ impl InnerKeyManager for ToInnerKeyManager {
         &self,
         public_jwk: Jwk,
     ) -> web5::crypto::key_managers::Result<Arc<dyn web5::crypto::dsa::Signer>> {
-        let outer_signer = self.0.get_signer(public_jwk).unwrap(); // 🚧 unwrap, need a .into() I think
+        let outer_signer = self.0.get_signer(public_jwk)?;
         let inner_signer = Arc::new(ToInnerSigner(outer_signer));
         Ok(inner_signer)
     }

--- a/bindings/web5_uniffi_wrapper/src/crypto/key_manager.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/key_manager.rs
@@ -1,26 +1,31 @@
-use super::dsa::{OuterSigner, Signer};
+use super::dsa::{ToOuterSigner, Signer, ToInnerSigner};
 use crate::errors::Result;
 use std::sync::Arc;
 use web5::crypto::{jwk::Jwk, key_managers::key_manager::KeyManager as InnerKeyManager};
 
 pub trait KeyManager: Send + Sync {
     fn get_signer(&self, public_jwk: Jwk) -> Result<Arc<dyn Signer>>;
-    fn to_inner(&self) -> Arc<dyn InnerKeyManager>;
 }
 
-pub struct OuterKeyManager(pub Arc<dyn InnerKeyManager>);
+pub struct ToOuterKeyManager(pub Arc<dyn InnerKeyManager>);
 
-impl KeyManager for OuterKeyManager {
+impl KeyManager for ToOuterKeyManager {
     fn get_signer(&self, public_jwk: Jwk) -> Result<Arc<dyn Signer>> {
-        let signer = self
-            .0
-            .get_signer(public_jwk)
-            .map_err(|e| Arc::new(e.into()))?;
-        let outer_signer = OuterSigner(signer);
+        let signer = self.0.get_signer(public_jwk)?;
+        let outer_signer = ToOuterSigner(signer);
         Ok(Arc::new(outer_signer))
     }
+}
 
-    fn to_inner(&self) -> Arc<dyn InnerKeyManager> {
-        self.0.clone()
+pub struct ToInnerKeyManager(pub Arc<dyn KeyManager>);
+
+impl InnerKeyManager for ToInnerKeyManager {
+    fn get_signer(
+        &self,
+        public_jwk: Jwk,
+    ) -> web5::crypto::key_managers::Result<Arc<dyn web5::crypto::dsa::Signer>> {
+        let outer_signer = self.0.get_signer(public_jwk).unwrap(); // 🚧 unwrap, need a .into() I think
+        let inner_signer = Arc::new(ToInnerSigner(outer_signer));
+        Ok(inner_signer)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/dids/bearer_did.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/bearer_did.rs
@@ -1,6 +1,6 @@
 use crate::{
     crypto::{
-        dsa::{ToOuterSigner, Signer},
+        dsa::{Signer, ToOuterSigner},
         key_manager::{KeyManager, ToInnerKeyManager, ToOuterKeyManager},
     },
     errors::Result,

--- a/bindings/web5_uniffi_wrapper/src/dids/bearer_did.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/bearer_did.rs
@@ -1,7 +1,7 @@
 use crate::{
     crypto::{
-        dsa::{OuterSigner, Signer},
-        key_manager::{KeyManager, OuterKeyManager},
+        dsa::{ToOuterSigner, Signer},
+        key_manager::{KeyManager, ToInnerKeyManager, ToOuterKeyManager},
     },
     errors::Result,
 };
@@ -20,13 +20,13 @@ pub struct BearerDid(pub InnerBearerDid);
 
 impl BearerDid {
     pub fn new(uri: &str, key_manager: Arc<dyn KeyManager>) -> Result<Self> {
-        let inner =
-            InnerBearerDid::new(uri, key_manager.to_inner()).map_err(|e| Arc::new(e.into()))?;
+        let inner_key_manager = Arc::new(ToInnerKeyManager(key_manager));
+        let inner = InnerBearerDid::new(uri, inner_key_manager)?;
         Ok(Self(inner))
     }
 
     pub fn get_data(&self) -> BearerDidData {
-        let outer_key_manager = OuterKeyManager(self.0.key_manager.clone());
+        let outer_key_manager = ToOuterKeyManager(self.0.key_manager.clone());
 
         BearerDidData {
             did: self.0.did.clone(),
@@ -36,8 +36,8 @@ impl BearerDid {
     }
 
     pub fn get_signer(&self, key_id: String) -> Result<Arc<dyn Signer>> {
-        let signer = self.0.get_signer(key_id).map_err(|e| Arc::new(e.into()))?;
-        let outer_signer = OuterSigner(signer);
+        let signer = self.0.get_signer(key_id)?;
+        let outer_signer = ToOuterSigner(signer);
         Ok(Arc::new(outer_signer))
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/dids/bearer_did.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/bearer_did.rs
@@ -10,6 +10,8 @@ use web5::dids::{
     bearer_did::BearerDid as InnerBearerDid, data_model::document::Document, did::Did,
 };
 
+use super::portable_did::PortableDid;
+
 pub struct BearerDidData {
     pub did: Did,
     pub document: Document,
@@ -23,6 +25,11 @@ impl BearerDid {
         let inner_key_manager = Arc::new(ToInnerKeyManager(key_manager));
         let inner = InnerBearerDid::new(uri, inner_key_manager)?;
         Ok(Self(inner))
+    }
+
+    pub fn from_portable_did(portable_did: Arc<PortableDid>) -> Result<Self> {
+        let inner_bearer_did = InnerBearerDid::from_portable_did(portable_did.get_data())?;
+        Ok(Self(inner_bearer_did))
     }
 
     pub fn get_data(&self) -> BearerDidData {

--- a/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
@@ -1,5 +1,4 @@
 use crate::errors::Result;
-use std::sync::Arc;
 use web5::{crypto::jwk::Jwk, dids::data_model::document::Document as InnerDocument};
 
 pub struct Document(pub InnerDocument);
@@ -14,8 +13,6 @@ impl Document {
     }
 
     pub fn find_public_key_jwk(&self, key_id: String) -> Result<Jwk> {
-        self.0
-            .find_public_key_jwk(key_id)
-            .map_err(|e| Arc::new(e.into()))
+        Ok(self.0.find_public_key_jwk(key_id)?)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/dids/did.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/did.rs
@@ -1,12 +1,11 @@
 use crate::errors::Result;
-use std::sync::Arc;
 use web5::dids::did::Did as InnerDid;
 
 pub struct Did(pub InnerDid);
 
 impl Did {
     pub fn new(uri: &str) -> Result<Self> {
-        let did = InnerDid::new(uri).map_err(|e| Arc::new(e.into()))?;
+        let did = InnerDid::new(uri)?;
         Ok(Self(did))
     }
 

--- a/bindings/web5_uniffi_wrapper/src/dids/methods/did_dht/mod.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/methods/did_dht/mod.rs
@@ -1,5 +1,7 @@
 use crate::{
-    crypto::dsa::Signer, dids::resolution::resolution_result::ResolutionResult, errors::Result,
+    crypto::dsa::{Signer, ToInnerSigner},
+    dids::resolution::resolution_result::ResolutionResult,
+    errors::Result,
 };
 use std::sync::Arc;
 use web5::{crypto::jwk::Jwk, dids::methods::did_dht::DidDht as InnerDidDht};
@@ -13,25 +15,23 @@ pub fn did_dht_resolve(uri: &str) -> Result<Arc<ResolutionResult>> {
 
 impl DidDht {
     pub fn from_identity_key(public_key: Jwk) -> Result<Self> {
-        let did_dht = InnerDidDht::from_identity_key(public_key).map_err(|e| Arc::new(e.into()))?;
+        let did_dht = InnerDidDht::from_identity_key(public_key)?;
         Ok(Self(did_dht))
     }
 
     pub fn from_uri(uri: &str) -> Result<Self> {
-        let did_dht = InnerDidDht::from_uri(uri).map_err(|e| Arc::new(e.into()))?;
+        let did_dht = InnerDidDht::from_uri(uri)?;
         Ok(Self(did_dht))
     }
 
     pub fn publish(&self, signer: Arc<dyn Signer>) -> Result<()> {
-        self.0
-            .publish(signer.to_inner())
-            .map_err(|e| Arc::new(e.into()))
+        let inner_signer = Arc::new(ToInnerSigner(signer));
+        Ok(self.0.publish(inner_signer)?)
     }
 
     pub fn deactivate(&self, signer: Arc<dyn Signer>) -> Result<()> {
-        self.0
-            .deactivate(signer.to_inner())
-            .map_err(|e| Arc::new(e.into()))
+        let inner_signer = Arc::new(ToInnerSigner(signer));
+        Ok(self.0.deactivate(inner_signer)?)
     }
 
     pub fn get_data(&self) -> InnerDidDht {

--- a/bindings/web5_uniffi_wrapper/src/dids/methods/did_jwk.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/methods/did_jwk.rs
@@ -11,12 +11,12 @@ pub fn did_jwk_resolve(uri: &str) -> Arc<ResolutionResult> {
 
 impl DidJwk {
     pub fn from_public_jwk(public_key: Jwk) -> Result<Self> {
-        let did_jwk = InnerDidJwk::from_public_jwk(public_key).map_err(|e| Arc::new(e.into()))?;
+        let did_jwk = InnerDidJwk::from_public_jwk(public_key)?;
         Ok(Self(did_jwk))
     }
 
     pub fn from_uri(uri: &str) -> Result<Self> {
-        let did_jwk = InnerDidJwk::from_uri(uri).map_err(|e| Arc::new(e.into()))?;
+        let did_jwk = InnerDidJwk::from_uri(uri)?;
         Ok(Self(did_jwk))
     }
 

--- a/bindings/web5_uniffi_wrapper/src/dids/methods/did_web.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/methods/did_web.rs
@@ -11,9 +11,7 @@ pub async fn did_web_resolve(uri: &str) -> Result<Arc<ResolutionResult>> {
 
 impl DidWeb {
     pub async fn from_uri(uri: &str) -> Result<Self> {
-        let did_web = InnerDidWeb::from_uri(uri)
-            .await
-            ?;
+        let did_web = InnerDidWeb::from_uri(uri).await?;
         Ok(Self(did_web))
     }
 

--- a/bindings/web5_uniffi_wrapper/src/dids/methods/did_web.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/methods/did_web.rs
@@ -13,7 +13,7 @@ impl DidWeb {
     pub async fn from_uri(uri: &str) -> Result<Self> {
         let did_web = InnerDidWeb::from_uri(uri)
             .await
-            .map_err(|e| Arc::new(e.into()))?;
+            ?;
         Ok(Self(did_web))
     }
 

--- a/bindings/web5_uniffi_wrapper/src/dids/mod.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/mod.rs
@@ -4,3 +4,4 @@ pub mod resolution;
 
 pub mod bearer_did;
 pub mod did;
+pub mod portable_did;

--- a/bindings/web5_uniffi_wrapper/src/dids/portable_did.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/portable_did.rs
@@ -1,0 +1,16 @@
+use web5::dids::portable_did::PortableDid as InnerPortableDid;
+
+use crate::errors::Result;
+
+pub struct PortableDid(pub InnerPortableDid);
+
+impl PortableDid {
+    pub fn new(json: &str) -> Result<Self> {
+        let inner_portable_did = InnerPortableDid::new(json)?;
+        Ok(Self(inner_portable_did))
+    }
+
+    pub fn get_data(&self) -> InnerPortableDid {
+        self.0.clone()
+    }
+}

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -10,6 +10,7 @@ use web5::dids::bearer_did::BearerDidError;
 use web5::dids::data_model::DataModelError as DidDataModelError;
 use web5::dids::did::DidError;
 use web5::dids::methods::MethodError;
+use web5::dids::portable_did::PortableDidError;
 
 #[derive(Debug, Error)]
 pub enum RustCoreError {
@@ -98,6 +99,12 @@ impl From<DsaError> for RustCoreError {
 
 impl From<DidError> for RustCoreError {
     fn from(error: DidError) -> Self {
+        RustCoreError::new(error)
+    }
+}
+
+impl From<PortableDidError> for RustCoreError {
+    fn from(error: PortableDidError) -> Self {
         RustCoreError::new(error)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -1,5 +1,5 @@
 use serde_json::Error as SerdeJsonError;
-use std::sync::{Arc, PoisonError};
+use std::sync::PoisonError;
 use std::{any::type_name, fmt::Debug};
 use thiserror::Error;
 use web5::credentials::presentation_definition::PexError;
@@ -13,21 +13,21 @@ use web5::dids::methods::MethodError;
 
 #[derive(Debug, Error)]
 pub enum RustCoreError {
-    #[error("{message}")]
+    #[error("{msg}")]
     Error {
         r#type: String,
         variant: String,
-        message: String,
+        msg: String,
     },
 }
 
 impl RustCoreError {
-    pub fn from_poison_error<T>(error: PoisonError<T>, error_type: &str) -> Arc<Self> {
-        Arc::new(RustCoreError::Error {
+    pub fn from_poison_error<T>(error: PoisonError<T>, error_type: &str) -> Self {
+        RustCoreError::Error {
             r#type: error_type.to_string(),
             variant: "PoisonError".to_string(),
-            message: error.to_string(),
-        })
+            msg: error.to_string(),
+        }
     }
 
     fn new<T>(error: T) -> Self
@@ -37,7 +37,7 @@ impl RustCoreError {
         Self::Error {
             r#type: type_of(&error).to_string(),
             variant: variant_name(&error),
-            message: error.to_string(),
+            msg: error.to_string(),
         }
     }
 
@@ -60,7 +60,7 @@ impl RustCoreError {
 
     pub fn message(&self) -> String {
         match self {
-            RustCoreError::Error { message, .. } => message.clone(),
+            RustCoreError::Error { msg: message, .. } => message.clone(),
         }
     }
 }
@@ -138,4 +138,4 @@ impl From<SerdeJsonError> for RustCoreError {
     }
 }
 
-pub type Result<T> = std::result::Result<T, Arc<RustCoreError>>;
+pub type Result<T> = std::result::Result<T, RustCoreError>;

--- a/crates/web5/src/crypto/dsa/mod.rs
+++ b/crates/web5/src/crypto/dsa/mod.rs
@@ -7,8 +7,8 @@ use base64::DecodeError;
 pub enum DsaError {
     #[error("missing required private key")]
     MissingPrivateKey,
-    #[error(transparent)]
-    DecodeError(#[from] DecodeError),
+    #[error("base64 decode error {0}")]
+    DecodeError(String),
     #[error("invalid key length {0}")]
     InvalidKeyLength(String),
     #[error("invalid signature length {0}")]
@@ -21,8 +21,16 @@ pub enum DsaError {
     VerificationFailure(String),
     #[error("sign failure {0}")]
     SignFailure(String),
-    #[error("Unsupported curve")]
+    #[error("unsupported curve")]
     UnsupportedDsa,
+    #[error("unknown error")]
+    Unknown,
+}
+
+impl From<DecodeError> for DsaError {
+    fn from(error: DecodeError) -> Self {
+        Self::DecodeError(error.to_string())
+    }
 }
 
 pub type Result<T> = std::result::Result<T, DsaError>;

--- a/crates/web5/src/crypto/dsa/mod.rs
+++ b/crates/web5/src/crypto/dsa/mod.rs
@@ -25,7 +25,7 @@ pub enum DsaError {
     UnsupportedDsa,
 }
 
-type Result<T> = std::result::Result<T, DsaError>;
+pub type Result<T> = std::result::Result<T, DsaError>;
 
 pub enum Dsa {
     Ed25519,

--- a/crates/web5/src/crypto/key_managers/mod.rs
+++ b/crates/web5/src/crypto/key_managers/mod.rs
@@ -13,6 +13,14 @@ pub enum KeyManagerError {
     InternalKeyStoreError(String),
     #[error("key not found {0}")]
     KeyNotFound(String),
+    #[error("unknown error")]
+    Unknown,
+}
+
+impl Default for KeyManagerError {
+    fn default() -> Self {
+        Self::Unknown
+    }
 }
 
 pub type Result<T> = std::result::Result<T, KeyManagerError>;

--- a/crates/web5/src/crypto/key_managers/mod.rs
+++ b/crates/web5/src/crypto/key_managers/mod.rs
@@ -15,4 +15,4 @@ pub enum KeyManagerError {
     KeyNotFound(String),
 }
 
-type Result<T> = std::result::Result<T, KeyManagerError>;
+pub type Result<T> = std::result::Result<T, KeyManagerError>;

--- a/crates/web5/src/dids/portable_did.rs
+++ b/crates/web5/src/dids/portable_did.rs
@@ -3,7 +3,7 @@ use crate::crypto::jwk::Jwk;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeJsonError;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PortableDid {
     #[serde(rename = "uri")]
     pub did_uri: String,


### PR DESCRIPTION
Add support for Kotlin to implement it's own instance of `Signer`, `Verifier` or `KeyManager` and utilize it inside the Rust bindings. Accomplished via [the `[WithForeign]` feature from UniFFI](https://mozilla.github.io/uniffi-rs/0.27/udl/interfaces.html#foreign-implementations).

As an added benefit of this, reworking the `RustCoreError` automatically prints the `type`, `variant` and `msg` line the following:

```
web5.sdk.rust.RustCoreException$Exception: type=test-type, variant=test-varient, msg=test-msg
```