### PR TITLE
Add CLI build workflow

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,0 +1,73 @@
+name: Build CLI
+
+on:
+  push:
+    branches:
+      - main
+      - kendall/cli-build
+  pull_request:
+
+jobs:
+  build_aarch64_apple_darwin:
+    runs-on: macos-latest
+    name: Build aarch64-apple-darwin target
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup toolchain install stable
+      - name: Run Build Script
+        run: |
+          cd crates/web5_cli/build/aarch64_apple_darwin
+          ./build
+      - name: Upload executable
+        uses: actions/upload-artifact@v3
+        with:
+          name: aarch64-apple-darwin-exe
+          path: target/aarch64-apple-darwin/release/web5_cli
+
+  build_x86_64_apple_darwin:
+    runs-on: macos-12
+    name: Build x86_64-apple-darwin target
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup toolchain install stable
+      - name: Run Build Script
+        run: |
+          cd crates/web5_cli/build/x86_64_apple_darwin
+          ./build
+      - name: Upload executable
+        uses: actions/upload-artifact@v3
+        with:
+          name: x86_64-apple-darwin-exe
+          path: target/x86_64-apple-darwin/release/web5_cli
+
+  build_x86_64_unknown_linux_gnu:
+    runs-on: ubuntu-latest
+    name: Build x86_64-unknown-linux-gnu target
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build Script
+        run: |
+          cd crates/web5_cli/build/x86_64_unknown_linux_gnu
+          ./build
+      - name: Upload executable
+        uses: actions/upload-artifact@v3
+        with:
+          name: x86_64-unknown-linux-gnu-exe
+          path: target/x86_64-unknown-linux-gnu/release/web5_cli
+
+  build_x86_64_unknown_linux_musl:
+    runs-on: ubuntu-latest
+    name: Build x86_64-unknown-linux-musl target
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build Script
+        run: |
+          cd crates/web5_cli/build/x86_64_unknown_linux_musl
+          ./build
+      - name: Upload executable
+        uses: actions/upload-artifact@v3
+        with:
+          name: x86_64-unknown-linux-musl-exe
+          path: target/x86_64-unknown-linux-musl/release/web5_cli

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - kendall/cli-build
   pull_request:
 
 jobs:
@@ -22,7 +21,7 @@ jobs:
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:
-          name: aarch64-apple-darwin-exe
+          name: web5-aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release/web5_cli
 
   build_x86_64_apple_darwin:
@@ -39,7 +38,7 @@ jobs:
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:
-          name: x86_64-apple-darwin-exe
+          name: web5-x86_64-apple-darwin
           path: target/x86_64-apple-darwin/release/web5_cli
 
   build_x86_64_unknown_linux_gnu:
@@ -54,7 +53,7 @@ jobs:
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:
-          name: x86_64-unknown-linux-gnu-exe
+          name: web5-x86_64-linux-gnu
           path: target/x86_64-unknown-linux-gnu/release/web5_cli
 
   build_x86_64_unknown_linux_musl:
@@ -69,5 +68,5 @@ jobs:
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:
-          name: x86_64-unknown-linux-musl-exe
+          name: web5-x86_64-linux-musl
           path: target/x86_64-unknown-linux-musl/release/web5_cli

--- a/crates/web5_cli/Cargo.toml
+++ b/crates/web5_cli/Cargo.toml
@@ -13,3 +13,12 @@ serde_json = { workspace = true }
 web5 = { path = "../web5" }
 url = "2.5.2"
 uuid = { workspace = true }
+
+[dependencies.openssl]
+version = "0.10"
+optional = true
+features = ["vendored"]
+
+[features]
+default = []
+x86_64_apple_darwin = ["openssl"] 

--- a/crates/web5_cli/build/aarch64_apple_darwin/build
+++ b/crates/web5_cli/build/aarch64_apple_darwin/build
@@ -1,0 +1,13 @@
+#!/bin/bash 
+
+set -e
+
+REPO_DIR=../../../../
+
+rustup target add aarch64-apple-darwin
+
+(
+  cd $REPO_DIR;
+  cargo build --target aarch64-apple-darwin --release --package web5_cli;
+  # located at: target/aarch64-apple-darwin/release/web5_cli
+)

--- a/crates/web5_cli/build/x86_64_apple_darwin/build
+++ b/crates/web5_cli/build/x86_64_apple_darwin/build
@@ -1,0 +1,15 @@
+#!/bin/bash 
+
+set -e
+
+REPO_DIR=../../../../
+
+rustup target add x86_64-apple-darwin
+
+(
+  cd $REPO_DIR;
+  cargo build --target x86_64-apple-darwin --release \
+    --package web5_cli \
+    --features x86_64_apple_darwin;
+  # located at target/x86_64-apple-darwin/release/web5_cli
+)

--- a/crates/web5_cli/build/x86_64_unknown_linux_gnu/Dockerfile
+++ b/crates/web5_cli/build/x86_64_unknown_linux_gnu/Dockerfile
@@ -1,0 +1,27 @@
+FROM --platform=linux/amd64 ubuntu:22.04
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    build-essential \
+    libssl-dev \
+    pkg-config
+
+# Install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Copy the source code to the container
+WORKDIR /usr/src/myapp
+COPY Cargo.toml ./
+COPY bindings/web5_uniffi_wrapper ./bindings/web5_uniffi_wrapper
+COPY bindings/web5_uniffi ./bindings/web5_uniffi
+COPY crates/web5 ./crates/web5
+COPY crates/web5_cli ./crates/web5_cli
+
+# Execute the build
+RUN cargo build --release --package web5_cli
+
+# Set the entrypoint, so that we can `docker cp` the build output
+CMD tail -f /dev/null

--- a/crates/web5_cli/build/x86_64_unknown_linux_gnu/build
+++ b/crates/web5_cli/build/x86_64_unknown_linux_gnu/build
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+REPO_DIR=../../../../
+IMAGE_NAME=web5_cli_x86_64-unknown-linux-gnu_image
+CONTAINER_NAME=web5_cli_x86_64-unknown-linux-gnu_container
+
+docker build -f $(pwd)/Dockerfile -t $IMAGE_NAME $REPO_DIR
+
+docker run -d --name $CONTAINER_NAME $IMAGE_NAME
+
+TARGET_DIR=$REPO_DIR/target/x86_64-unknown-linux-gnu/release
+mkdir -p $TARGET_DIR
+
+docker cp $CONTAINER_NAME:/usr/src/myapp/target/release/web5_cli $TARGET_DIR/web5_cli
+
+docker stop $CONTAINER_NAME
+docker rm $CONTAINER_NAME

--- a/crates/web5_cli/build/x86_64_unknown_linux_musl/Dockerfile
+++ b/crates/web5_cli/build/x86_64_unknown_linux_musl/Dockerfile
@@ -1,0 +1,31 @@
+FROM --platform=linux/amd64 alpine:latest
+
+# Install system dependencies
+RUN apk add --no-cache \
+    build-base \
+    musl-dev \
+    openssl-dev \
+    linux-headers \
+    rustup \
+    libgcc \
+    libstdc++ \
+    curl \
+    git \
+    openssl-libs-static
+
+# Install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Copy the source code to the container
+WORKDIR /usr/src/myapp
+COPY Cargo.toml ./
+COPY bindings/web5_uniffi_wrapper ./bindings/web5_uniffi_wrapper
+COPY bindings/web5_uniffi ./bindings/web5_uniffi
+COPY crates/web5 ./crates/web5
+COPY crates/web5_cli ./crates/web5_cli
+
+RUN cargo build --release --package web5_cli
+
+# Set the entrypoint, so that we can `docker cp` the build output
+CMD tail -f /dev/null

--- a/crates/web5_cli/build/x86_64_unknown_linux_musl/build
+++ b/crates/web5_cli/build/x86_64_unknown_linux_musl/build
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+REPO_DIR=../../../../
+IMAGE_NAME=web5_cli_x86_64-unknown-linux-musl_image
+CONTAINER_NAME=web5_cli_x86_64-unknown-linux-musl_container
+
+docker build -f $(pwd)/Dockerfile -t $IMAGE_NAME $REPO_DIR
+
+docker run -d --name $CONTAINER_NAME $IMAGE_NAME
+
+TARGET_DIR=$REPO_DIR/target/x86_64-unknown-linux-musl/release
+mkdir -p $TARGET_DIR
+
+docker cp $CONTAINER_NAME:/usr/src/myapp/target/release/web5_cli $TARGET_DIR/web5_cli
+
+docker stop $CONTAINER_NAME
+docker rm $CONTAINER_NAME

--- a/crates/web5_cli/install.sh
+++ b/crates/web5_cli/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+VERSION=$1
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case $OS in
+  "linux")
+    case $ARCH in
+      "x86_64") FILENAME="web5-x86_64-linux-gnu.zip" ;;
+      *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+    esac
+    ;;
+  "darwin")
+    case $ARCH in
+      "x86_64") FILENAME="web5-x86_64-apple-darwin.zip" ;;
+      "arm64") FILENAME="web5-aarch64-apple-darwin.zip" ;;
+      *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Download and unzip
+curl -L -o /tmp/$FILENAME https://github.com/TBD54566975/web5-rs/releases/download/$VERSION/$FILENAME
+unzip -o /tmp/$FILENAME -d /tmp
+
+# Move the executable to /usr/local/bin and make it executable
+sudo mv /tmp/web5_cli /usr/local/bin/web5
+sudo chmod +x /usr/local/bin/web5
+
+# Cleanup
+rm /tmp/$FILENAME


### PR DESCRIPTION
- Add GitHub Workflow yml for building the CLI executable for all four targets
- Add the `crates/web5_cli/build` directory full of build scripts for all four targets 
- Add `crates/web5_cli/install.sh` script

That last bit is such that we can simply do this one-liner across (most) Linux and macOS environments

```shell
curl -L https://raw.githubusercontent.com/TBD54566975/web5-rs/crates/web5_cli/install.sh | bash -s v0.0.3
```