### PR TITLE
Add PortableDid, use existing UniFFI interfaces

### DIFF
--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/InMemoryKeyManager.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/InMemoryKeyManager.kt
@@ -1,10 +1,8 @@
 package web5.sdk.crypto.keys
 
-import web5.sdk.crypto.signers.OuterSigner
 import web5.sdk.crypto.signers.Signer
 import web5.sdk.rust.SystemTarget
 import web5.sdk.rust.InMemoryKeyManager as RustCoreInMemoryKeyManager
-import web5.sdk.rust.KeyManager as RustCoreKeyManager
 
 /**
  * A class for managing cryptographic keys in-memory.
@@ -34,17 +32,7 @@ class InMemoryKeyManager : KeyManager {
      * @return Signer The signer for the given public key.
      */
     override fun getSigner(publicJwk: Jwk): Signer {
-        val innerSigner = this.rustCoreInMemoryKeyManager.getSigner(publicJwk)
-        return OuterSigner(innerSigner)
-    }
-
-    /**
-     * Returns the RustCoreKeyManager.
-     *
-     * @return RustCoreKeyManager The rust core key manager.
-     */
-    override fun getRustCoreKeyManager(): RustCoreKeyManager {
-        return this.rustCoreInMemoryKeyManager.getAsKeyManager()
+        return this.rustCoreInMemoryKeyManager.getSigner(publicJwk)
     }
 
     /**

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/KeyManager.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/KeyManager.kt
@@ -1,25 +1,6 @@
 package web5.sdk.crypto.keys
 
-import web5.sdk.crypto.signers.Signer
 import web5.sdk.rust.KeyManager as RustCoreKeyManager
 
-/**
- * An interface representing a key manager for cryptographic operations.
- */
-interface KeyManager {
+typealias KeyManager = RustCoreKeyManager
 
-    /**
-     * Returns the signer for the given public key.
-     *
-     * @param publicKey The public key represented as a Jwk.
-     * @return Signer The signer for the given public key.
-     */
-    fun getSigner(publicJwk: Jwk): Signer
-
-    /**
-     * Returns the RustCoreKeyManager
-     *
-     * @return RustCoreKeyManager The rust core key manager
-     */
-    fun getRustCoreKeyManager(): RustCoreKeyManager
-}

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Signer.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Signer.kt
@@ -1,24 +1,5 @@
 package web5.sdk.crypto.signers
 
-import web5.sdk.rust.SystemTarget
 import web5.sdk.rust.Signer as RustCoreSigner
 
-interface Signer {
-    fun sign(payload: ByteArray): ByteArray
-}
-
-class OuterSigner: Signer {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
-    private val rustCoreSigner: RustCoreSigner
-
-    constructor(rustCoreSigner: RustCoreSigner) {
-        this.rustCoreSigner = rustCoreSigner
-    }
-
-    override fun sign(payload: ByteArray): ByteArray {
-        return this.rustCoreSigner.sign(payload)
-    }
-}
+typealias Signer = RustCoreSigner

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
@@ -2,7 +2,6 @@ package web5.sdk.dids
 
 import web5.sdk.crypto.signers.Signer
 import web5.sdk.crypto.keys.KeyManager
-import web5.sdk.crypto.signers.OuterSigner
 import web5.sdk.rust.SystemTarget
 
 import web5.sdk.rust.BearerDid as RustCoreBearerDid
@@ -32,11 +31,25 @@ class BearerDid {
      * @param keyManager The key manager to handle keys.
      */
     constructor(uri: String, keyManager: KeyManager) {
-        this.rustCoreBearerDid = RustCoreBearerDid(uri, keyManager.getRustCoreKeyManager())
+        this.rustCoreBearerDid = RustCoreBearerDid(uri, keyManager)
 
         this.did = this.rustCoreBearerDid.getData().did
         this.document = this.rustCoreBearerDid.getData().document
         this.keyManager = keyManager
+    }
+
+    /**
+     * Constructs a BearerDid instance from a PortableDid.
+     *
+     * @param portableDid The PortableDid.
+     */
+    constructor(portableDid: PortableDid) {
+        this.rustCoreBearerDid = RustCoreBearerDid.fromPortableDid(portableDid.rustCorePortableDid)
+
+        val data = this.rustCoreBearerDid.getData()
+        this.did = data.did
+        this.document = data.document
+        this.keyManager = data.keyManager
     }
 
     /**
@@ -46,7 +59,6 @@ class BearerDid {
      */
     fun getSigner(): Signer {
         val keyId = this.document.verificationMethod.first().id
-        val innerSigner = this.rustCoreBearerDid.getSigner(keyId)
-        return OuterSigner(innerSigner)
+        return this.rustCoreBearerDid.getSigner(keyId)
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
@@ -1,0 +1,25 @@
+package web5.sdk.dids
+
+import web5.sdk.crypto.keys.Jwk
+import web5.sdk.rust.SystemTarget
+import web5.sdk.rust.PortableDid as RustCorePortableDid
+
+class PortableDid {
+    init {
+        SystemTarget.set() // ensure the sys arch is set for first-time loading
+    }
+
+    val didUri: String
+    val document: Document
+    val privateKeys: List<Jwk>
+
+    internal val rustCorePortableDid: RustCorePortableDid
+
+    constructor(json: String) {
+        this.rustCorePortableDid = RustCorePortableDid(json)
+
+        this.didUri = rustCorePortableDid.getData().didUri
+        this.document = rustCorePortableDid.getData().document
+        this.privateKeys = rustCorePortableDid.getData().privateJwks
+    }
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
@@ -15,6 +15,11 @@ class PortableDid {
 
     internal val rustCorePortableDid: RustCorePortableDid
 
+    /**
+     * Constructs a PortableDid from a JSON string.
+     *
+     * @param json The JSON string.
+     */
     constructor(json: String) {
         this.rustCorePortableDid = RustCorePortableDid(json)
 

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/PortableDidTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/PortableDidTest.kt
@@ -1,0 +1,29 @@
+package web5.sdk.dids
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import web5.sdk.rust.RustCoreException
+
+class PortableDidTest {
+    @Test
+    fun `can instantiate from json string`() {
+        val jsonString = """
+            {"uri":"did:web:tbd.website%3A9002:alice","document":{"id":"did:web:tbd.website%3A9002:alice","@context":["https://www.w3.org/ns/did/v1"],"verificationMethod":[{"id":"did:web:tbd.website%3A9002:alice#key-0","type":"JsonWebKey","controller":"did:web:tbd.website%3A9002:alice","publicKeyJwk":{"alg":"Ed25519","kty":"OKP","crv":"Ed25519","x":"NNoVSv_v34ombmylF572t9HYYDiJtMgfckRT1W0vW0g"}}]},"privateKeys":[{"alg":"Ed25519","kty":"OKP","crv":"Ed25519","d":"SwuWbL-Fm64OUFy6x3FBt3RiB79RcnZZrllGT24m4BA","x":"NNoVSv_v34ombmylF572t9HYYDiJtMgfckRT1W0vW0g"}]}
+        """.trimIndent()
+
+        assertDoesNotThrow {
+            val portableDid = PortableDid(jsonString)
+            assertEquals("did:web:tbd.website%3A9002:alice", portableDid.didUri)
+        }
+    }
+
+    @Test
+    fun `instantiation from json string throws with invalid json string`() {
+        val invalidJsonString = "something not valid"
+        assertThrows(RustCoreException::class.java) {
+            PortableDid(invalidJsonString)
+        }
+    }
+}


### PR DESCRIPTION
- Add `PortableDid`
- Add constructor for `BearerDid` to instantiate from a `PortableDid`
- Remove unnecessary interfaces and simply reuse the UniFFI generated
  - This is now possible with the recently added `[WithForeign]` UniFFI feature