### PR TITLE
Move sys target initialization to inside UniFFI.kt

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,7 @@ bind-kotlin: setup
     generate --library bound/kt/src/main/resources/libweb5_uniffi_aarch64_apple_darwin.dylib \
     --language kotlin \
     --out-dir target/bindgen-kotlin
+  sed -i '' 's/findLibraryName(componentName)/detectSystemTarget()/' target/bindgen-kotlin/web5/sdk/rust/web5.kt
   cp target/bindgen-kotlin/web5/sdk/rust/web5.kt bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
 
 test-bound: setup

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/InMemoryKeyManager.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/InMemoryKeyManager.kt
@@ -1,17 +1,12 @@
 package web5.sdk.crypto.keys
 
 import web5.sdk.crypto.signers.Signer
-import web5.sdk.rust.SystemTarget
 import web5.sdk.rust.InMemoryKeyManager as RustCoreInMemoryKeyManager
 
 /**
  * A class for managing cryptographic keys in-memory.
  */
 class InMemoryKeyManager : KeyManager {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     private val rustCoreInMemoryKeyManager = RustCoreInMemoryKeyManager()
 
     /**

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Ed25519Signer.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Ed25519Signer.kt
@@ -1,15 +1,9 @@
 package web5.sdk.crypto.signers
 
 import web5.sdk.crypto.keys.Jwk
-import web5.sdk.rust.SystemTarget
-
 import web5.sdk.rust.Ed25519Signer as RustCoreEd25519Signer
 
 class Ed25519Signer : Signer {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     private val rustCoreSigner: RustCoreEd25519Signer
 
     constructor(privateKey: Jwk) {

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
@@ -2,8 +2,6 @@ package web5.sdk.dids
 
 import web5.sdk.crypto.signers.Signer
 import web5.sdk.crypto.keys.KeyManager
-import web5.sdk.rust.SystemTarget
-
 import web5.sdk.rust.BearerDid as RustCoreBearerDid
 
 /**
@@ -14,10 +12,6 @@ import web5.sdk.rust.BearerDid as RustCoreBearerDid
  * @property document The DID document associated with this instance.
  */
 class BearerDid {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     val did: Did
     val document: Document
     val keyManager: KeyManager

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/Document.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/Document.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids
 
-
 import web5.sdk.rust.DocumentData as RustCoreDocumentData
 
 /**

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
@@ -1,14 +1,9 @@
 package web5.sdk.dids
 
 import web5.sdk.crypto.keys.Jwk
-import web5.sdk.rust.SystemTarget
 import web5.sdk.rust.PortableDid as RustCorePortableDid
 
 class PortableDid {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     val didUri: String
     val document: Document
     val privateKeys: List<Jwk>

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -5,8 +5,6 @@ import web5.sdk.crypto.signers.Signer
 import web5.sdk.dids.Did
 import web5.sdk.dids.Document
 import web5.sdk.dids.ResolutionResult
-import web5.sdk.rust.SystemTarget
-
 import web5.sdk.rust.didDhtResolve as rustCoreDidDhtResolve
 import web5.sdk.rust.DidDht as RustCoreDidDht
 import web5.sdk.rust.Signer as RustCoreSigner
@@ -18,10 +16,6 @@ import web5.sdk.rust.Signer as RustCoreSigner
  * @property document The DID document associated with this instance.
  */
 class DidDht {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     val did: Did
     val document: Document
 

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -4,8 +4,6 @@ import web5.sdk.crypto.keys.Jwk
 import web5.sdk.dids.Did
 import web5.sdk.dids.Document
 import web5.sdk.dids.ResolutionResult
-import web5.sdk.rust.SystemTarget
-
 import web5.sdk.rust.didJwkResolve as rustCoreDidJwkResolve
 import web5.sdk.rust.DidJwk as RustCoreDidJwk
 
@@ -16,10 +14,6 @@ import web5.sdk.rust.DidJwk as RustCoreDidJwk
  * @property document The DID document associated with this instance.
  */
 class DidJwk {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     val did: Did
     val document: Document
 

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
@@ -5,8 +5,6 @@ import web5.sdk.crypto.keys.Jwk
 import web5.sdk.dids.Did
 import web5.sdk.dids.Document
 import web5.sdk.dids.ResolutionResult
-import web5.sdk.rust.SystemTarget
-
 import web5.sdk.rust.didWebResolve as rustCoreDidWebResolve
 import web5.sdk.rust.DidWeb as RustCoreDidWeb
 
@@ -17,10 +15,6 @@ import web5.sdk.rust.DidWeb as RustCoreDidWeb
  * @property document The DID document associated with this instance.
  */
 class DidWeb {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     val did: Did
     val document: Document
 

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/SystemTarget.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/SystemTarget.kt
@@ -2,59 +2,47 @@ package web5.sdk.rust
 
 import java.io.File
 
-object SystemTarget {
-    @Volatile
-    private var isSet = false
+internal val logLevel = System.getenv("WEB5_SDK_LOG_LEVEL")?.lowercase()
 
-    fun set() {
-        val logLevel = System.getenv("WEB5_SDK_LOG_LEVEL")?.lowercase()
+internal fun log(message: String) {
+    if (logLevel == "debug") {
+        println("web5 sdk SystemArchitecture $message")
+    }
+}
 
-        fun log(message: String) {
-            if (logLevel == "debug") {
-                println("web5 sdk SystemArchitecture $message")
-            }
-        }
+internal fun detectSystemTarget(): String {
+    val arch = System.getProperty("os.arch")?.lowercase() ?: throw Exception("Unable to get OS arch")
+    val name = System.getProperty("os.name")?.lowercase() ?: throw Exception("Unable to get OS name")
 
-        if (!isSet) {
-            synchronized(this) {
-                if (!isSet) {
-                    val arch = System.getProperty("os.arch")?.lowercase() ?: throw Exception("Unable to get OS arch")
-                    val name = System.getProperty("os.name")?.lowercase() ?: throw Exception("Unable to get OS name")
+    log("System architecture: $arch")
+    log("Operating system name: $name")
 
-                    log("System architecture: $arch")
-                    log("Operating system name: $name")
+    when {
+        name.contains("mac") && arch.contains("aarch64") ->
+            return "web5_uniffi_aarch64_apple_darwin"
 
-                    when {
-                        name.contains("mac") && arch.contains("aarch64") ->
-                            System.setProperty("uniffi.component.web5.libraryOverride", "web5_uniffi_aarch64_apple_darwin")
+        name.contains("mac") && arch.contains("x86_64") ->
+            return "web5_uniffi_x86_64_apple_darwin"
 
-                        name.contains("mac") && arch.contains("x86_64") ->
-                            System.setProperty("uniffi.component.web5.libraryOverride", "web5_uniffi_x86_64_apple_darwin")
+        name.contains("linux") && arch.contains("amd64") -> {
+            val osRelease = File("/etc/os-release")
+            if (osRelease.exists()) {
+                val osReleaseContent = osRelease.readText().lowercase()
+                log("OS release content: $osReleaseContent")
+                return when {
+                    osReleaseContent.contains("ubuntu") ->
+                        "web5_uniffi_x86_64_unknown_linux_gnu"
 
-                        name.contains("linux") && arch.contains("amd64") -> {
-                            val osRelease = File("/etc/os-release")
-                            if (osRelease.exists()) {
-                                val osReleaseContent = osRelease.readText().lowercase()
-                                log("OS release content: $osReleaseContent")
-                                when {
-                                    osReleaseContent.contains("ubuntu") ->
-                                        System.setProperty("uniffi.component.web5.libraryOverride", "web5_uniffi_x86_64_unknown_linux_gnu")
+                    osReleaseContent.contains("alpine") ->
+                        "web5_uniffi_x86_64_unknown_linux_musl"
 
-                                    osReleaseContent.contains("alpine") ->
-                                        System.setProperty("uniffi.component.web5.libraryOverride", "web5_uniffi_x86_64_unknown_linux_musl")
-
-                                    else -> throw Exception("Unsupported OS arch $osReleaseContent")
-                                }
-                            } else {
-                                throw Exception("Linux /etc/os-release not found")
-                            }
-                        }
-
-                        else -> throw Exception("Unsupported OS arch $arch $name")
-                    }
-                    isSet = true
+                    else -> throw Exception("Unsupported OS arch $osReleaseContent")
                 }
+            } else {
+                throw Exception("Linux /etc/os-release not found")
             }
         }
+
+        else -> throw Exception("Unsupported OS arch $arch $name")
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -367,7 +367,7 @@ private fun findLibraryName(componentName: String): String {
 private inline fun <reified Lib : Library> loadIndirect(
     componentName: String
 ): Lib {
-    return Native.load<Lib>(findLibraryName(componentName), Lib::class.java)
+    return Native.load<Lib>(detectSystemTarget(), Lib::class.java)
 }
 
 // Define FFI callback types

--- a/bound/kt/src/main/kotlin/web5/sdk/vc/pex/PresentationDefinition.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/vc/pex/PresentationDefinition.kt
@@ -2,7 +2,6 @@ package web5.sdk.vc.pex
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import web5.sdk.Json
-import web5.sdk.rust.SystemTarget
 import web5.sdk.rust.PresentationDefinition as RustCorePresentationDefinition
 
 data class PresentationDefinition(
@@ -12,10 +11,6 @@ data class PresentationDefinition(
     @JsonProperty("input_descriptors")
     val inputDescriptors: List<InputDescriptor>
 ) {
-    init {
-        SystemTarget.set() // ensure the sys arch is set for first-time loading
-    }
-
     internal val rustCorePresentationDefinition = RustCorePresentationDefinition(
         Json.stringify(this)
     )

--- a/bound/kt/src/test/kotlin/web5/sdk/rust/SystemTargetTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/rust/SystemTargetTest.kt
@@ -7,6 +7,6 @@ class SystemTargetTest {
     fun `can load shared library`() {
         System.setProperty("WEB5_SDK_LOG_LEVEL", "debug")
         UniffiLib.INSTANCE
-        println("Successfully loaded shared library for ${System.getProperty("uniffi.component.web5.libraryOverride")}")
+        println("Successfully loaded shared library for ${detectSystemTarget()}")
     }
 }

--- a/bound/kt/src/test/kotlin/web5/sdk/rust/SystemTargetTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/rust/SystemTargetTest.kt
@@ -6,7 +6,6 @@ class SystemTargetTest {
     @Test
     fun `can load shared library`() {
         System.setProperty("WEB5_SDK_LOG_LEVEL", "debug")
-        SystemTarget.set()
         UniffiLib.INSTANCE
         println("Successfully loaded shared library for ${System.getProperty("uniffi.component.web5.libraryOverride")}")
     }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,0 @@
-# jitpack.yml
-
-jdk:
-  - openjdk11
-
-install:
-  - cd bound/kt && mvn install -DskipTests=true


### PR DESCRIPTION
This is the wholly remove the possibility of code paths being introduced which fail to first call `SystemTarget.set()`. We ran into this during integration testing of `tbdex-rs/bound/kt` wherein the Kotlin `companion object`'s offered routes for which the call to `SystemTarget.set()` wasn't made, and therefore the loading of the byte code failed in non-macOS aarch64 (the default) settings.

This requires us to augment the code-gen'd `UniFFI.kt` file in our `Justfile`, but all things considered, this is the least invasive (known solution) which is also the most robust.