### PR TITLE
Add feature complete Jwk

### DIFF
--- a/bindings/web5_uniffi/src/lib.rs
+++ b/bindings/web5_uniffi/src/lib.rs
@@ -9,6 +9,7 @@ use web5_uniffi_wrapper::{
             Signer, Verifier,
         },
         in_memory_key_manager::InMemoryKeyManager,
+        jwk::Jwk,
         key_manager::KeyManager,
     },
     dids::{

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -119,8 +119,6 @@ dictionary ServiceData {
 interface Document {
   constructor(DocumentData data);
   DocumentData get_data();
-  [Throws=Web5Error]
-  JwkData find_public_key_jwk(string key_id);
 };
 
 enum ResolutionMetadataError {
@@ -210,9 +208,11 @@ dictionary PortableDidData {
 };
 
 interface PortableDid {
-  [Throws=Web5Error]
+  [Name=from_json_string, Throws=Web5Error]
   constructor([ByRef] string json);
   PortableDidData get_data();
+  [Throws=Web5Error]
+  string to_json_string();
 };
 
 dictionary BearerDidData {

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -22,6 +22,13 @@ dictionary JwkData {
   string? y;
 };
 
+interface Jwk {
+  constructor(JwkData data);
+  JwkData get_data();
+  [Throws=Web5Error]
+  string compute_thumbprint();
+};
+
 [Trait, WithForeign]
 interface KeyManager {
   [Throws=Web5Error]

--- a/bindings/web5_uniffi_wrapper/src/crypto/jwk.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/jwk.rs
@@ -1,0 +1,19 @@
+use crate::errors::Result;
+use web5::crypto::jwk::Jwk as InnerJwk;
+
+pub struct Jwk(pub InnerJwk);
+
+impl Jwk {
+    pub fn new(data: InnerJwk) -> Self {
+        Self(data)
+    }
+
+    pub fn get_data(&self) -> InnerJwk {
+        self.0.clone()
+    }
+
+    pub fn compute_thumbprint(&self) -> Result<String> {
+        let thumbprint = self.0.compute_thumbprint()?;
+        Ok(thumbprint)
+    }
+}

--- a/bindings/web5_uniffi_wrapper/src/crypto/mod.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/mod.rs
@@ -1,4 +1,5 @@
 pub mod dsa;
 
 pub mod in_memory_key_manager;
+pub mod jwk;
 pub mod key_manager;

--- a/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
@@ -1,5 +1,4 @@
-use crate::errors::Result;
-use web5::{crypto::jwk::Jwk, dids::data_model::document::Document as InnerDocument};
+use web5::dids::data_model::document::Document as InnerDocument;
 
 pub struct Document(pub InnerDocument);
 
@@ -10,9 +9,5 @@ impl Document {
 
     pub fn get_data(&self) -> InnerDocument {
         self.0.clone()
-    }
-
-    pub fn find_public_key_jwk(&self, key_id: String) -> Result<Jwk> {
-        Ok(self.0.find_public_key_jwk(key_id)?)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/dids/portable_did.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/portable_did.rs
@@ -1,16 +1,23 @@
-use web5::dids::portable_did::PortableDid as InnerPortableDid;
-
 use crate::errors::Result;
+use web5::{
+    dids::portable_did::PortableDid as InnerPortableDid,
+    json::{FromJson, ToJson},
+};
 
 pub struct PortableDid(pub InnerPortableDid);
 
 impl PortableDid {
-    pub fn new(json: &str) -> Result<Self> {
-        let inner_portable_did = InnerPortableDid::new(json)?;
+    pub fn from_json_string(json: &str) -> Result<Self> {
+        let inner_portable_did = InnerPortableDid::from_json_string(json)?;
         Ok(Self(inner_portable_did))
     }
 
     pub fn get_data(&self) -> InnerPortableDid {
         self.0.clone()
+    }
+
+    pub fn to_json_string(&self) -> Result<String> {
+        let json_string = self.0.to_json_string()?;
+        Ok(json_string)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -7,9 +7,7 @@ use web5::credentials::CredentialError;
 use web5::crypto::dsa::DsaError;
 use web5::crypto::key_managers::KeyManagerError;
 use web5::dids::bearer_did::BearerDidError;
-use web5::dids::data_model::DataModelError as DidDataModelError;
 use web5::dids::methods::MethodError;
-use web5::dids::portable_did::PortableDidError;
 use web5::errors::Web5Error as InnerWeb5Error;
 
 #[derive(Debug, Error)]
@@ -91,12 +89,6 @@ impl From<DsaError> for Web5Error {
     }
 }
 
-impl From<PortableDidError> for Web5Error {
-    fn from(error: PortableDidError) -> Self {
-        Web5Error::new(error)
-    }
-}
-
 impl From<MethodError> for Web5Error {
     fn from(error: MethodError) -> Self {
         Web5Error::new(error)
@@ -111,12 +103,6 @@ impl From<CredentialError> for Web5Error {
 
 impl From<PexError> for Web5Error {
     fn from(error: PexError) -> Self {
-        Web5Error::new(error)
-    }
-}
-
-impl From<DidDataModelError> for Web5Error {
-    fn from(error: DidDataModelError) -> Self {
         Web5Error::new(error)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use web5::credentials::presentation_definition::PexError;
 use web5::credentials::CredentialError;
 use web5::crypto::dsa::DsaError;
-use web5::crypto::{jwk::JwkError, key_managers::KeyManagerError};
+use web5::crypto::key_managers::KeyManagerError;
 use web5::dids::bearer_did::BearerDidError;
 use web5::dids::data_model::DataModelError as DidDataModelError;
 use web5::dids::methods::MethodError;
@@ -79,12 +79,6 @@ where
     variant_name.to_string()
 }
 
-impl From<JwkError> for Web5Error {
-    fn from(error: JwkError) -> Self {
-        Web5Error::new(error)
-    }
-}
-
 impl From<KeyManagerError> for Web5Error {
     fn from(error: KeyManagerError) -> Self {
         Web5Error::new(error)
@@ -144,13 +138,7 @@ impl From<Web5Error> for KeyManagerError {
         let variant = error.variant();
         let msg = error.msg();
 
-        if variant
-            == variant_name(&KeyManagerError::JwkError(JwkError::ThumbprintFailed(
-                String::default(),
-            )))
-        {
-            return KeyManagerError::JwkError(JwkError::ThumbprintFailed(msg.to_string()));
-        } else if variant == variant_name(&KeyManagerError::KeyGenerationFailed) {
+        if variant == variant_name(&KeyManagerError::KeyGenerationFailed) {
             return KeyManagerError::KeyGenerationFailed;
         } else if variant
             == variant_name(&KeyManagerError::InternalKeyStoreError(String::default()))

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/InMemoryKeyManager.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/InMemoryKeyManager.kt
@@ -1,5 +1,6 @@
 package web5.sdk.crypto.keys
 
+import web5.sdk.crypto.signers.ToOuterSigner
 import web5.sdk.crypto.signers.Signer
 import web5.sdk.rust.InMemoryKeyManager as RustCoreInMemoryKeyManager
 
@@ -16,7 +17,7 @@ class InMemoryKeyManager : KeyManager {
      */
     constructor(privateJwks: List<Jwk>) {
         privateJwks.forEach {
-            this.rustCoreInMemoryKeyManager.importPrivateJwk(it)
+            this.rustCoreInMemoryKeyManager.importPrivateJwk(it.rustCoreJwkData)
         }
     }
 
@@ -27,7 +28,8 @@ class InMemoryKeyManager : KeyManager {
      * @return Signer The signer for the given public key.
      */
     override fun getSigner(publicJwk: Jwk): Signer {
-        return this.rustCoreInMemoryKeyManager.getSigner(publicJwk)
+        val rustCoreSigner = this.rustCoreInMemoryKeyManager.getSigner(publicJwk.rustCoreJwkData)
+        return ToOuterSigner(rustCoreSigner)
     }
 
     /**
@@ -37,6 +39,7 @@ class InMemoryKeyManager : KeyManager {
      * @return Jwk The public key represented as a JWK.
      */
     fun importPrivateJwk(privateJwk: Jwk): Jwk {
-        return this.rustCoreInMemoryKeyManager.importPrivateJwk(privateJwk)
+        val rustCoreJwkData = this.rustCoreInMemoryKeyManager.importPrivateJwk(privateJwk.rustCoreJwkData)
+        return Jwk.fromRustCoreJwkData(rustCoreJwkData)
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/Jwk.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/Jwk.kt
@@ -1,10 +1,44 @@
 package web5.sdk.crypto.keys
 
+import web5.sdk.rust.Jwk as RustCoreJwk
 import web5.sdk.rust.JwkData as RustCoreJwkData
 
 /**
  * Partial representation of a [JSON Web Key as per RFC7517](https://tools.ietf.org/html/rfc7517).
  * Note that this is a subset of the spec.
  */
+data class Jwk (
+    val alg: String? = null,
+    val kty: String,
+    val crv: String,
+    val x: String,
+    val y: String? = null,
+    val d: String? = null
+) {
+    internal val rustCoreJwkData: RustCoreJwkData = RustCoreJwkData(
+        alg,
+        kty,
+        crv,
+        d,
+        x,
+        y
+    )
 
-typealias Jwk = RustCoreJwkData
+    internal companion object {
+        fun fromRustCoreJwkData(rustCoreJwkData: RustCoreJwkData): Jwk {
+            return Jwk(
+                rustCoreJwkData.alg,
+                rustCoreJwkData.kty,
+                rustCoreJwkData.crv,
+                rustCoreJwkData.x,
+                rustCoreJwkData.y,
+                rustCoreJwkData.d,
+            )
+        }
+    }
+
+    fun computeThumbprint(): String {
+        val rustCoreJwk = RustCoreJwk(rustCoreJwkData)
+        return rustCoreJwk.computeThumbprint()
+    }
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/KeyManager.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/keys/KeyManager.kt
@@ -1,6 +1,28 @@
 package web5.sdk.crypto.keys
 
+import web5.sdk.crypto.signers.ToOuterSigner
+import web5.sdk.crypto.signers.Signer
+import web5.sdk.crypto.signers.ToInnerSigner
+import web5.sdk.rust.JwkData as RustCoreJwkData
 import web5.sdk.rust.KeyManager as RustCoreKeyManager
+import web5.sdk.rust.Signer as RustCoreSigner
 
-typealias KeyManager = RustCoreKeyManager
+interface KeyManager {
+    fun getSigner(publicJwk: Jwk): Signer
+}
 
+internal class ToOuterKeyManager(private val rustCoreKeyManager: RustCoreKeyManager) : KeyManager {
+    override fun getSigner(publicJwk: Jwk): Signer {
+        val rustCoreSigner = rustCoreKeyManager.getSigner(publicJwk.rustCoreJwkData)
+        return ToOuterSigner(rustCoreSigner)
+    }
+}
+
+internal class ToInnerKeyManager(private val keyManager: KeyManager) : RustCoreKeyManager {
+    override fun getSigner(publicJwk: RustCoreJwkData): RustCoreSigner {
+        val jwk = Jwk.fromRustCoreJwkData(publicJwk)
+        val signer = keyManager.getSigner(jwk)
+        val innerSigner = ToInnerSigner(signer)
+        return innerSigner
+    }
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Ed25519Signer.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Ed25519Signer.kt
@@ -7,7 +7,7 @@ class Ed25519Signer : Signer {
     private val rustCoreSigner: RustCoreEd25519Signer
 
     constructor(privateKey: Jwk) {
-        this.rustCoreSigner = RustCoreEd25519Signer(privateKey)
+        this.rustCoreSigner = RustCoreEd25519Signer(privateKey.rustCoreJwkData)
     }
 
     private constructor(rustCoreSigner: RustCoreEd25519Signer) {

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Signer.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Signer.kt
@@ -2,4 +2,18 @@ package web5.sdk.crypto.signers
 
 import web5.sdk.rust.Signer as RustCoreSigner
 
-typealias Signer = RustCoreSigner
+interface Signer {
+    fun sign(payload: ByteArray): ByteArray
+}
+
+internal class ToOuterSigner(private val rustCoreSigner: RustCoreSigner) : Signer {
+    override fun sign(payload: ByteArray): ByteArray {
+        return rustCoreSigner.sign(payload)
+    }
+}
+
+internal class ToInnerSigner(private val signer: Signer) : RustCoreSigner {
+    override fun sign(payload: ByteArray): ByteArray {
+        return signer.sign(payload)
+    }
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
@@ -2,6 +2,9 @@ package web5.sdk.dids
 
 import web5.sdk.crypto.signers.Signer
 import web5.sdk.crypto.keys.KeyManager
+import web5.sdk.crypto.keys.ToInnerKeyManager
+import web5.sdk.crypto.keys.ToOuterKeyManager
+import web5.sdk.crypto.signers.ToOuterSigner
 import web5.sdk.rust.BearerDid as RustCoreBearerDid
 
 /**
@@ -25,7 +28,8 @@ class BearerDid {
      * @param keyManager The key manager to handle keys.
      */
     constructor(uri: String, keyManager: KeyManager) {
-        this.rustCoreBearerDid = RustCoreBearerDid(uri, keyManager)
+        val innerKeyManager = ToInnerKeyManager(keyManager)
+        this.rustCoreBearerDid = RustCoreBearerDid(uri, innerKeyManager)
 
         this.did = Did.fromRustCoreDidData(this.rustCoreBearerDid.getData().did)
         this.document = this.rustCoreBearerDid.getData().document
@@ -43,7 +47,7 @@ class BearerDid {
         val data = this.rustCoreBearerDid.getData()
         this.did = Did.fromRustCoreDidData(data.did)
         this.document = data.document
-        this.keyManager = data.keyManager
+        this.keyManager = ToOuterKeyManager(data.keyManager)
     }
 
     /**
@@ -53,6 +57,6 @@ class BearerDid {
      */
     fun getSigner(): Signer {
         val keyId = this.document.verificationMethod.first().id
-        return this.rustCoreBearerDid.getSigner(keyId)
+        return ToOuterSigner(this.rustCoreBearerDid.getSigner(keyId))
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/Did.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/Did.kt
@@ -20,7 +20,7 @@ data class Did (
         fun parse(uri: String): Did {
             val rustCoreDid = RustCoreDid(uri)
             val data = rustCoreDid.getData()
-            return Did.fromRustCoreDidData(data)
+            return fromRustCoreDidData(data)
         }
 
         internal fun fromRustCoreDidData(data: RustCoreDidData): Did {

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
@@ -20,6 +20,6 @@ class PortableDid {
 
         this.didUri = rustCorePortableDid.getData().didUri
         this.document = rustCorePortableDid.getData().document
-        this.privateKeys = rustCorePortableDid.getData().privateJwks
+        this.privateKeys = rustCorePortableDid.getData().privateJwks.map {Jwk.fromRustCoreJwkData(it) }
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
@@ -3,23 +3,34 @@ package web5.sdk.dids
 import web5.sdk.crypto.keys.Jwk
 import web5.sdk.rust.PortableDid as RustCorePortableDid
 
-class PortableDid {
-    val didUri: String
-    val document: Document
-    val privateKeys: List<Jwk>
-
+class PortableDid private constructor(
+    val didUri: String,
+    val document: Document,
+    val privateKeys: List<Jwk>,
     internal val rustCorePortableDid: RustCorePortableDid
-
+) {
     /**
      * Constructs a PortableDid from a JSON string.
      *
      * @param json The JSON string.
      */
-    constructor(json: String) {
-        this.rustCorePortableDid = RustCorePortableDid(json)
+    companion object {
+        fun fromJsonString(json: String): PortableDid {
+            val rustCorePortableDid = RustCorePortableDid.fromJsonString(json)
+            val data = rustCorePortableDid.getData()
+            return PortableDid(
+                data.didUri,
+                data.document,
+                data.privateJwks.map { Jwk.fromRustCoreJwkData(it) },
+                rustCorePortableDid
+            )
+        }
+    }
 
-        this.didUri = rustCorePortableDid.getData().didUri
-        this.document = rustCorePortableDid.getData().document
-        this.privateKeys = rustCorePortableDid.getData().privateJwks.map {Jwk.fromRustCoreJwkData(it) }
+    /**
+     * Serializes a PortableDid to a JSON string.
+     */
+    fun toJsonString(): String {
+        return rustCorePortableDid.toJsonString()
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -27,7 +27,7 @@ class DidDht {
      * @param identityKey The identity key represented as a Jwk.
      */
     constructor(identityKey: Jwk) {
-        rustCoreDidDht = RustCoreDidDht.fromIdentityKey(identityKey)
+        rustCoreDidDht = RustCoreDidDht.fromIdentityKey(identityKey.rustCoreJwkData)
 
         this.did = Did.fromRustCoreDidData(rustCoreDidDht.getData().did)
         this.document = rustCoreDidDht.getData().document

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -23,7 +23,7 @@ class DidJwk {
      * @param publicKey The public key represented as a Jwk.
      */
     constructor(publicKey: Jwk) {
-        val rustCoreDidJwk = RustCoreDidJwk.fromPublicJwk(publicKey)
+        val rustCoreDidJwk = RustCoreDidJwk.fromPublicJwk(publicKey.rustCoreJwkData)
 
         this.did = Did.fromRustCoreDidData(rustCoreDidJwk.getData().did)
         this.document = rustCoreDidJwk.getData().document

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
@@ -39,7 +39,7 @@ class DidWeb {
      */
     constructor(domain: String, publicKey: Jwk) {
         val rustCoreDidWeb = runBlocking {
-            RustCoreDidWeb.fromPublicJwk(domain, publicKey);
+            RustCoreDidWeb.fromPublicJwk(domain, publicKey.rustCoreJwkData);
         }
 
         this.did = Did.fromRustCoreDidData(rustCoreDidWeb.getData().did)

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -968,8 +968,6 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_web5_uniffi_fn_constructor_document_new(`data`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
-    fun uniffi_web5_uniffi_fn_method_document_find_public_key_jwk(`ptr`: Pointer,`keyId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_method_document_get_data(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_clone_ed25519signer(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -1022,9 +1020,11 @@ internal interface UniffiLib : Library {
     ): Pointer
     fun uniffi_web5_uniffi_fn_free_portabledid(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
-    fun uniffi_web5_uniffi_fn_constructor_portabledid_new(`json`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    fun uniffi_web5_uniffi_fn_constructor_portabledid_from_json_string(`json`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_web5_uniffi_fn_method_portabledid_get_data(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    fun uniffi_web5_uniffi_fn_method_portabledid_to_json_string(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_clone_presentationdefinition(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
@@ -1212,8 +1212,6 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_method_didweb_get_data(
     ): Short
-    fun uniffi_web5_uniffi_checksum_method_document_find_public_key_jwk(
-    ): Short
     fun uniffi_web5_uniffi_checksum_method_document_get_data(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_ed25519signer_sign(
@@ -1233,6 +1231,8 @@ internal interface UniffiLib : Library {
     fun uniffi_web5_uniffi_checksum_method_keymanager_get_signer(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_portabledid_get_data(
+    ): Short
+    fun uniffi_web5_uniffi_checksum_method_portabledid_to_json_string(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition(
     ): Short
@@ -1274,7 +1274,7 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_jwk_new(
     ): Short
-    fun uniffi_web5_uniffi_checksum_constructor_portabledid_new(
+    fun uniffi_web5_uniffi_checksum_constructor_portabledid_from_json_string(
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_presentationdefinition_new(
     ): Short
@@ -1335,9 +1335,6 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_method_didweb_get_data() != 40916.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_web5_uniffi_checksum_method_document_find_public_key_jwk() != 16969.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
     if (lib.uniffi_web5_uniffi_checksum_method_document_get_data() != 16490.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1366,6 +1363,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_method_portabledid_get_data() != 27045.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_web5_uniffi_checksum_method_portabledid_to_json_string() != 53673.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition() != 52261.toShort()) {
@@ -1428,7 +1428,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_constructor_jwk_new() != 59888.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_web5_uniffi_checksum_constructor_portabledid_new() != 37852.toShort()) {
+    if (lib.uniffi_web5_uniffi_checksum_constructor_portabledid_from_json_string() != 64165.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_constructor_presentationdefinition_new() != 13282.toShort()) {
@@ -3113,8 +3113,6 @@ public object FfiConverterTypeDidWeb: FfiConverter<DidWeb, Pointer> {
 
 public interface DocumentInterface {
     
-    fun `findPublicKeyJwk`(`keyId`: kotlin.String): JwkData
-    
     fun `getData`(): DocumentData
     
     companion object
@@ -3207,19 +3205,6 @@ open class Document: Disposable, AutoCloseable, DocumentInterface {
             UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_clone_document(pointer!!, status)
         }
     }
-
-    
-    @Throws(Web5Exception::class)override fun `findPublicKeyJwk`(`keyId`: kotlin.String): JwkData {
-            return FfiConverterTypeJwkData.lift(
-    callWithPointer {
-    uniffiRustCallWithError(Web5Exception) { _status ->
-    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_document_find_public_key_jwk(
-        it, FfiConverterString.lower(`keyId`),_status)
-}
-    }
-    )
-    }
-    
 
     override fun `getData`(): DocumentData {
             return FfiConverterTypeDocumentData.lift(
@@ -4673,6 +4658,8 @@ public interface PortableDidInterface {
     
     fun `getData`(): PortableDidData
     
+    fun `toJsonString`(): kotlin.String
+    
     companion object
 }
 
@@ -4693,13 +4680,6 @@ open class PortableDid: Disposable, AutoCloseable, PortableDidInterface {
         this.pointer = null
         this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
     }
-    constructor(`json`: kotlin.String) :
-        this(
-    uniffiRustCallWithError(Web5Exception) { _status ->
-    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_constructor_portabledid_new(
-        FfiConverterString.lower(`json`),_status)
-}
-    )
 
     protected val pointer: Pointer?
     protected val cleanable: UniffiCleaner.Cleanable
@@ -4777,10 +4757,35 @@ open class PortableDid: Disposable, AutoCloseable, PortableDidInterface {
     
 
     
+    @Throws(Web5Exception::class)override fun `toJsonString`(): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_portabledid_to_json_string(
+        it, _status)
+}
+    }
+    )
+    }
+    
 
     
+
     
-    companion object
+    companion object {
+        
+    @Throws(Web5Exception::class) fun `fromJsonString`(`json`: kotlin.String): PortableDid {
+            return FfiConverterTypePortableDid.lift(
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_constructor_portabledid_from_json_string(
+        FfiConverterString.lower(`json`),_status)
+}
+    )
+    }
+    
+
+        
+    }
     
 }
 

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -878,6 +878,14 @@ internal open class UniffiVTableCallbackInterfaceVerifier(
 
 
 
+
+
+
+
+
+
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -991,6 +999,16 @@ internal interface UniffiLib : Library {
     fun uniffi_web5_uniffi_fn_method_inmemorykeymanager_get_signer(`ptr`: Pointer,`publicJwk`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_web5_uniffi_fn_method_inmemorykeymanager_import_private_jwk(`ptr`: Pointer,`privateKey`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    fun uniffi_web5_uniffi_fn_clone_jwk(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Pointer
+    fun uniffi_web5_uniffi_fn_free_jwk(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    fun uniffi_web5_uniffi_fn_constructor_jwk_new(`data`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Pointer
+    fun uniffi_web5_uniffi_fn_method_jwk_compute_thumbprint(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    fun uniffi_web5_uniffi_fn_method_jwk_get_data(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_clone_keymanager(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
@@ -1208,6 +1226,10 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_method_inmemorykeymanager_import_private_jwk(
     ): Short
+    fun uniffi_web5_uniffi_checksum_method_jwk_compute_thumbprint(
+    ): Short
+    fun uniffi_web5_uniffi_checksum_method_jwk_get_data(
+    ): Short
     fun uniffi_web5_uniffi_checksum_method_keymanager_get_signer(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_portabledid_get_data(
@@ -1249,6 +1271,8 @@ internal interface UniffiLib : Library {
     fun uniffi_web5_uniffi_checksum_constructor_ed25519verifier_new(
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_inmemorykeymanager_new(
+    ): Short
+    fun uniffi_web5_uniffi_checksum_constructor_jwk_new(
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_portabledid_new(
     ): Short
@@ -1332,6 +1356,12 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_method_inmemorykeymanager_import_private_jwk() != 54213.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_web5_uniffi_checksum_method_jwk_compute_thumbprint() != 15254.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_web5_uniffi_checksum_method_jwk_get_data() != 12450.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_web5_uniffi_checksum_method_keymanager_get_signer() != 27148.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1393,6 +1423,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_constructor_inmemorykeymanager_new() != 16598.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_web5_uniffi_checksum_constructor_jwk_new() != 59888.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_constructor_portabledid_new() != 37852.toShort()) {
@@ -3976,6 +4009,260 @@ public object FfiConverterTypeInMemoryKeyManager: FfiConverter<InMemoryKeyManage
     override fun allocationSize(value: InMemoryKeyManager) = 8UL
 
     override fun write(value: InMemoryKeyManager, buf: ByteBuffer) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+public interface JwkInterface {
+    
+    fun `computeThumbprint`(): kotlin.String
+    
+    fun `getData`(): JwkData
+    
+    companion object
+}
+
+open class Jwk: Disposable, AutoCloseable, JwkInterface {
+
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+    constructor(`data`: JwkData) :
+        this(
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_constructor_jwk_new(
+        FfiConverterTypeJwkData.lower(`data`),_status)
+}
+    )
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val pointer: Pointer?) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_free_jwk(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer {
+        return uniffiRustCall() { status ->
+            UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_clone_jwk(pointer!!, status)
+        }
+    }
+
+    
+    @Throws(Web5Exception::class)override fun `computeThumbprint`(): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_jwk_compute_thumbprint(
+        it, _status)
+}
+    }
+    )
+    }
+    
+
+    override fun `getData`(): JwkData {
+            return FfiConverterTypeJwkData.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_jwk_get_data(
+        it, _status)
+}
+    }
+    )
+    }
+    
+
+    
+
+    
+    
+    companion object
+    
+}
+
+public object FfiConverterTypeJwk: FfiConverter<Jwk, Pointer> {
+
+    override fun lower(value: Jwk): Pointer {
+        return value.uniffiClonePointer()
+    }
+
+    override fun lift(value: Pointer): Jwk {
+        return Jwk(value)
+    }
+
+    override fun read(buf: ByteBuffer): Jwk {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Jwk) = 8UL
+
+    override fun write(value: Jwk, buf: ByteBuffer) {
         // The Rust code always expects pointers written as 8 bytes,
         // and will fail to compile if they don't fit.
         buf.putLong(Pointer.nativeValue(lower(value)))

--- a/bound/kt/src/test/kotlin/web5/sdk/crypto/keys/InMemoryKeyManagerTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/crypto/keys/InMemoryKeyManagerTest.kt
@@ -14,9 +14,9 @@ class InMemoryKeyManagerTest {
   fun `test key manager`() {
     val privateJwk = rustCoreEd25519GeneratorGenerate()
 
-    val keyManager = InMemoryKeyManager(listOf(privateJwk))
+    val keyManager = InMemoryKeyManager(listOf(Jwk.fromRustCoreJwkData(privateJwk)))
 
-    val signer = keyManager.getSigner(privateJwk)
+    val signer = keyManager.getSigner(Jwk.fromRustCoreJwkData(privateJwk))
     val payload = signer.sign("abc".toByteArray())
 
     assertNotNull(payload)
@@ -36,10 +36,10 @@ class InMemoryKeyManagerTest {
     val privateJwk = rustCoreEd25519GeneratorGenerate()
 
     val keyManager = InMemoryKeyManager(listOf())
-    keyManager.importPrivateJwk(privateJwk)
+    keyManager.importPrivateJwk(Jwk.fromRustCoreJwkData(privateJwk))
 
     privateJwk.d = null
-    val signer = keyManager.getSigner(privateJwk)
+    val signer = keyManager.getSigner(Jwk.fromRustCoreJwkData(privateJwk))
     val payload = signer.sign("abc".toByteArray())
 
     assertNotNull(payload)

--- a/bound/kt/src/test/kotlin/web5/sdk/crypto/keys/JwkTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/crypto/keys/JwkTest.kt
@@ -1,0 +1,148 @@
+package web5.sdk.crypto.keys
+
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.fail
+import web5.sdk.UnitTestSuite
+import web5.sdk.rust.Web5Exception
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JwkTest {
+
+    private val testSuite = UnitTestSuite("jwk_compute_thumbprint")
+
+    @AfterAll
+    fun verifyAllTestsIncluded() {
+        if (testSuite.tests.isNotEmpty()) {
+            println("The following tests were not included or executed:")
+            testSuite.tests.forEach { println(it) }
+            fail("Not all tests were executed! ${this.testSuite.tests}")
+        }
+    }
+
+    @Test
+    fun test_ec_valid() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "EC",
+            crv = "secp256k1",
+            x = "x_value",
+            y = "y_value"
+        )
+
+        val thumbprint = jwk.computeThumbprint()
+        assertEquals("yiiszVT5Lwt6760MW19cHaJ61qJKIfe20sUW8dNxBv4", thumbprint)
+    }
+
+    @Test
+    fun test_okp_valid() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "OKP",
+            crv = "Ed25519",
+            x = "x_value"
+        )
+
+        val thumbprint = jwk.computeThumbprint()
+        assertEquals("nDMRVZm4lpedGjuJGO4y3YVJJ0krDF0aSz4KhlncDdI", thumbprint)
+    }
+
+    @Test
+    fun test_unsupported_kty() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "RSA",
+            crv = "RS256",
+            x = "x_value",
+            y = "y_value"
+        )
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            jwk.computeThumbprint()
+        }
+
+        assertEquals("data member error kty not supported RSA", exception.msg)
+    }
+
+    @Test
+    fun test_empty_kty() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "",
+            crv = "Ed25519",
+            x = "x_value"
+        )
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            jwk.computeThumbprint()
+        }
+
+        assertEquals("data member error kty cannot be empty", exception.msg)
+    }
+
+    @Test
+    fun test_empty_x() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "OKP",
+            crv = "Ed25519",
+            x = ""
+        )
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            jwk.computeThumbprint()
+        }
+
+        assertEquals("data member error x cannot be empty", exception.msg)
+    }
+
+    @Test
+    fun test_empty_crv() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "EC",
+            crv = "",
+            x = "x_value",
+            y = "y_value"
+        )
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            jwk.computeThumbprint()
+        }
+
+        assertEquals("data member error crv cannot be empty", exception.msg)
+    }
+
+    @Test
+    fun test_ec_missing_y() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "EC",
+            crv = "P-256",
+            x = "x_value"
+        )
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            jwk.computeThumbprint()
+        }
+
+        assertEquals("data member error missing y", exception.msg)
+    }
+
+    @Test
+    fun test_ec_empty_y() {
+        this.testSuite.include()
+        val jwk = Jwk(
+            kty = "EC",
+            crv = "P-256",
+            x = "x_value",
+            y = ""
+        )
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            jwk.computeThumbprint()
+        }
+
+        assertEquals("data member error y cannot be empty", exception.msg)
+    }
+}

--- a/bound/kt/src/test/kotlin/web5/sdk/crypto/signers/Ed25519SignerTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/crypto/signers/Ed25519SignerTest.kt
@@ -3,6 +3,7 @@ package web5.sdk.crypto.signers
 import org.junit.jupiter.api.Test
 import web5.sdk.crypto.keys.InMemoryKeyManager
 import org.junit.jupiter.api.Assertions.assertNotNull
+import web5.sdk.crypto.keys.Jwk
 
 import web5.sdk.rust.ed25519GeneratorGenerate as rustCoreEd25519GeneratorGenerate
 
@@ -11,7 +12,7 @@ class Ed25519SignerTest {
     @Test
     fun `test signer`() {
         val rustCorePrivateJwk = rustCoreEd25519GeneratorGenerate()
-        val ed25519Signer = Ed25519Signer(rustCorePrivateJwk)
+        val ed25519Signer = Ed25519Signer(Jwk.fromRustCoreJwkData(rustCorePrivateJwk))
 
         val payload = ed25519Signer.sign("abc".toByteArray())
 
@@ -23,7 +24,7 @@ class Ed25519SignerTest {
         val privateJwk = rustCoreEd25519GeneratorGenerate()
 
         val keyManager = InMemoryKeyManager(listOf())
-        val publicJwk = keyManager.importPrivateJwk(privateJwk)
+        val publicJwk = keyManager.importPrivateJwk(Jwk.fromRustCoreJwkData(privateJwk))
 
         val ed25519Signer = keyManager.getSigner(publicJwk)
         val payload = ed25519Signer.sign("abc".toByteArray())

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/BearerDidTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/BearerDidTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import web5.sdk.crypto.keys.InMemoryKeyManager
+import web5.sdk.crypto.keys.Jwk
 import web5.sdk.dids.methods.jwk.DidJwk
 import web5.sdk.rust.ed25519GeneratorGenerate
 
@@ -14,7 +15,7 @@ class BearerDidTest {
         val privateJwk = ed25519GeneratorGenerate()
 
         val keyManager = InMemoryKeyManager(listOf())
-        val publicJwk = keyManager.importPrivateJwk(privateJwk)
+        val publicJwk = keyManager.importPrivateJwk(Jwk.fromRustCoreJwkData(privateJwk))
 
         val didJwk = DidJwk(publicJwk)
 
@@ -28,7 +29,7 @@ class BearerDidTest {
         val privateJwk = ed25519GeneratorGenerate()
 
         val keyManager = InMemoryKeyManager(listOf())
-        val publicJwk = keyManager.importPrivateJwk(privateJwk)
+        val publicJwk = keyManager.importPrivateJwk(Jwk.fromRustCoreJwkData(privateJwk))
 
         val didJwk = DidJwk(publicJwk)
 

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/PortableDidTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/PortableDidTest.kt
@@ -14,7 +14,7 @@ class PortableDidTest {
         """.trimIndent()
 
         assertDoesNotThrow {
-            val portableDid = PortableDid(jsonString)
+            val portableDid = PortableDid.fromJsonString(jsonString)
             assertEquals("did:web:tbd.website%3A9002:alice", portableDid.didUri)
         }
     }
@@ -23,7 +23,20 @@ class PortableDidTest {
     fun `instantiation from json string throws with invalid json string`() {
         val invalidJsonString = "something not valid"
         assertThrows(Web5Exception::class.java) {
-            PortableDid(invalidJsonString)
+            PortableDid.fromJsonString(invalidJsonString)
+        }
+    }
+
+    @Test
+    fun `can serialize to a json string`() {
+        val jsonString = """
+            {"uri":"did:web:tbd.website%3A9002:alice","document":{"id":"did:web:tbd.website%3A9002:alice","@context":["https://www.w3.org/ns/did/v1"],"verificationMethod":[{"id":"did:web:tbd.website%3A9002:alice#key-0","type":"JsonWebKey","controller":"did:web:tbd.website%3A9002:alice","publicKeyJwk":{"alg":"Ed25519","kty":"OKP","crv":"Ed25519","x":"NNoVSv_v34ombmylF572t9HYYDiJtMgfckRT1W0vW0g"}}]},"privateKeys":[{"alg":"Ed25519","kty":"OKP","crv":"Ed25519","d":"SwuWbL-Fm64OUFy6x3FBt3RiB79RcnZZrllGT24m4BA","x":"NNoVSv_v34ombmylF572t9HYYDiJtMgfckRT1W0vW0g"}]}
+        """.trimIndent()
+
+        assertDoesNotThrow {
+            val portableDid = PortableDid.fromJsonString(jsonString)
+            val serializedJsonString = portableDid.toJsonString()
+            assertEquals(jsonString, serializedJsonString)
         }
     }
 }

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTests.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTests.kt
@@ -2,6 +2,7 @@ package web5.sdk.dids.methods.dht
 
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
+import web5.sdk.crypto.keys.Jwk
 
 import web5.sdk.rust.ed25519GeneratorGenerate as rustCoreEd25519GeneratorGenerate
 
@@ -10,7 +11,7 @@ class DidDhtTests {
     fun `can create did dht`() {
         val jwk = rustCoreEd25519GeneratorGenerate()
 
-        val didDht = DidDht(jwk)
+        val didDht = DidDht(Jwk.fromRustCoreJwkData(jwk))
 
         assertNotNull(didDht.document.id)
     }

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTests.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTests.kt
@@ -2,6 +2,7 @@ package web5.sdk.dids.methods.jwk
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import web5.sdk.crypto.keys.Jwk
 
 import web5.sdk.rust.DidJwk as RustCoreDidJwk
 
@@ -12,7 +13,7 @@ class DidJwkTests {
     fun `can create did jwk same as rust core`() {
         val jwk = rustCoreEd25519GeneratorGenerate()
 
-        val didJwk = DidJwk(jwk)
+        val didJwk = DidJwk(Jwk.fromRustCoreJwkData(jwk))
 
         val rustCoreDidJwk = RustCoreDidJwk.fromPublicJwk(jwk);
         assertEquals(rustCoreDidJwk.getData().did.uri, didJwk.did.uri)

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/methods/web/DidWebTests.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/methods/web/DidWebTests.kt
@@ -2,6 +2,7 @@ package web5.sdk.dids.methods.web
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import web5.sdk.crypto.keys.Jwk
 import web5.sdk.rust.ed25519GeneratorGenerate
 
 class DidWebTests {
@@ -11,7 +12,7 @@ class DidWebTests {
         val domain = "example.com"
         val jwk = ed25519GeneratorGenerate();
 
-        val didWeb = DidWeb(domain, jwk)
+        val didWeb = DidWeb(domain, Jwk.fromRustCoreJwkData(jwk))
         assertEquals(didWeb.did.uri, "did:web:example.com")
         assertEquals(didWeb.document.verificationMethod.get(0).publicKeyJwk, jwk)
     }

--- a/crates/web5/src/credentials/mod.rs
+++ b/crates/web5/src/credentials/mod.rs
@@ -6,8 +6,7 @@ use serde_json::Error as SerdeJsonError;
 use crate::errors::Web5Error;
 
 use super::dids::{
-    bearer_did::BearerDidError, data_model::DataModelError,
-    resolution::resolution_metadata::ResolutionMetadataError,
+    bearer_did::BearerDidError, resolution::resolution_metadata::ResolutionMetadataError,
 };
 
 pub mod presentation_definition;
@@ -37,8 +36,6 @@ pub enum CredentialError {
     MissingKid,
     #[error(transparent)]
     Resolution(#[from] ResolutionMetadataError),
-    #[error(transparent)]
-    DidDataModel(#[from] DataModelError),
     #[error(transparent)]
     Web5Error(#[from] Web5Error),
     #[error(transparent)]

--- a/crates/web5/src/credentials/verifiable_credential_1_1.rs
+++ b/crates/web5/src/credentials/verifiable_credential_1_1.rs
@@ -266,7 +266,7 @@ impl VerifiableCredential {
             .ok_or_else(|| {
                 JosekitError::InvalidJwtFormat(ResolutionMetadataError::InternalError.into())
             })?
-            .find_public_key_jwk(kid.to_string())?;
+            .find_public_jwk(kid.to_string())?;
 
         let verifier = Ed25519Verifier::new(public_key_jwk);
 

--- a/crates/web5/src/crypto/jwk.rs
+++ b/crates/web5/src/crypto/jwk.rs
@@ -1,3 +1,4 @@
+use crate::errors::{Result, Web5Error};
 use base64::{engine::general_purpose, Engine};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -16,37 +17,43 @@ pub struct Jwk {
 }
 
 impl Jwk {
-    pub fn is_private_key(&self) -> bool {
-        self.d.is_some()
-    }
-
-    pub fn is_public_key(&self) -> bool {
+    pub(crate) fn is_public_key(&self) -> bool {
         self.d.is_none()
     }
 }
 
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
-pub enum JwkError {
-    #[error("thumbprint computation failed {0}")]
-    ThumbprintFailed(String),
-}
-
-type Result<T> = std::result::Result<T, JwkError>;
-
 impl Jwk {
     pub fn compute_thumbprint(&self) -> Result<String> {
+        if self.kty.is_empty() {
+            return Err(Web5Error::DataMember("kty cannot be empty".to_string()));
+        }
+
+        if self.x.is_empty() {
+            return Err(Web5Error::DataMember("x cannot be empty".to_string()));
+        }
+
+        if self.crv.is_empty() {
+            return Err(Web5Error::DataMember("crv cannot be empty".to_string()));
+        }
+
         let thumbprint_json_string = match self.kty.as_str() {
-            "EC" => format!(
-                r#"{{"crv":"{}","kty":"EC","x":"{}","y":"{}"}}"#,
-                self.crv,
-                self.x,
-                self.y
+            "EC" => {
+                let y = self
+                    .y
                     .as_ref()
-                    .ok_or(JwkError::ThumbprintFailed("missing y".to_string()))?,
-            ),
-            "OKP" => format!(r#"{{"crv":"{}","kty":"OKP","x":"{}"}}"#, self.crv, self.x,),
+                    .ok_or(Web5Error::DataMember("missing y".to_string()))?;
+                if y.is_empty() {
+                    return Err(Web5Error::DataMember("y cannot be empty".to_string()));
+                }
+
+                format!(
+                    r#"{{"crv":"{}","kty":"EC","x":"{}","y":"{}"}}"#,
+                    self.crv, self.x, y,
+                )
+            }
+            "OKP" => format!(r#"{{"crv":"{}","kty":"OKP","x":"{}"}}"#, self.crv, self.x),
             _ => {
-                return Err(JwkError::ThumbprintFailed(format!(
+                return Err(Web5Error::DataMember(format!(
                     "kty not supported {0}",
                     self.kty
                 )))
@@ -59,5 +66,161 @@ impl Jwk {
         let thumbprint = general_purpose::URL_SAFE_NO_PAD.encode(digest);
 
         Ok(thumbprint)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod compute_thumbprint {
+        use super::*;
+        use crate::{errors::Web5Error, test_helpers::UnitTestSuite, test_name};
+        use std::sync::LazyLock;
+
+        static TEST_SUITE: LazyLock<UnitTestSuite> =
+            LazyLock::new(|| UnitTestSuite::new("jwk_compute_thumbprint"));
+
+        #[test]
+        fn z_assert_all_suite_cases_covered() {
+            // fn name prefixed with `z_*` b/c rust test harness executes in alphabetical order,
+            // unless intentionally executed with "shuffle" https://doc.rust-lang.org/rustc/tests/index.html#--shuffle
+            // this may not work if shuffled or if test list grows to the extent of 100ms being insufficient wait time
+
+            // wait 100ms to be last-in-queue of mutex lock
+            std::thread::sleep(std::time::Duration::from_millis(100));
+
+            TEST_SUITE.assert_coverage()
+        }
+
+        #[test]
+        fn test_ec_valid() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "EC".to_string(),
+                crv: "secp256k1".to_string(),
+                x: "x_value".to_string(),
+                y: Some("y_value".to_string()),
+                ..Default::default()
+            };
+
+            let thumbprint = jwk.compute_thumbprint().unwrap();
+            assert_eq!(thumbprint, "yiiszVT5Lwt6760MW19cHaJ61qJKIfe20sUW8dNxBv4");
+        }
+
+        #[test]
+        fn test_okp_valid() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "OKP".to_string(),
+                crv: "Ed25519".to_string(),
+                x: "x_value".to_string(),
+                ..Default::default()
+            };
+
+            let thumbprint = jwk.compute_thumbprint().unwrap();
+            assert_eq!(thumbprint, "nDMRVZm4lpedGjuJGO4y3YVJJ0krDF0aSz4KhlncDdI");
+        }
+
+        #[test]
+        fn test_unsupported_kty() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "RSA".to_string(),
+                crv: "RS256".to_string(),
+                x: "x_value".to_string(),
+                y: Some("y_value".to_string()),
+                ..Default::default()
+            };
+
+            let err = jwk.compute_thumbprint().unwrap_err();
+            assert!(matches!(err, Web5Error::DataMember(_)));
+            assert_eq!(err.to_string(), "data member error kty not supported RSA");
+        }
+
+        #[test]
+        fn test_empty_kty() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "".to_string(),
+                crv: "Ed25519".to_string(),
+                x: "x_value".to_string(),
+                ..Default::default()
+            };
+
+            let err = jwk.compute_thumbprint().unwrap_err();
+            assert!(matches!(err, Web5Error::DataMember(_)));
+            assert_eq!(err.to_string(), "data member error kty cannot be empty");
+        }
+
+        #[test]
+        fn test_empty_x() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "OKP".to_string(),
+                crv: "Ed25519".to_string(),
+                x: "".to_string(),
+                ..Default::default()
+            };
+
+            let err = jwk.compute_thumbprint().unwrap_err();
+            assert!(matches!(err, Web5Error::DataMember(_)));
+            assert_eq!(err.to_string(), "data member error x cannot be empty");
+        }
+
+        #[test]
+        fn test_empty_crv() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "EC".to_string(),
+                crv: "".to_string(),
+                x: "x_value".to_string(),
+                y: Some("y_value".to_string()),
+                ..Default::default()
+            };
+
+            let err = jwk.compute_thumbprint().unwrap_err();
+            assert!(matches!(err, Web5Error::DataMember(_)));
+            assert_eq!(err.to_string(), "data member error crv cannot be empty");
+        }
+
+        #[test]
+        fn test_ec_missing_y() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "EC".to_string(),
+                crv: "P-256".to_string(),
+                x: "x_value".to_string(),
+                ..Default::default()
+            };
+
+            let err = jwk.compute_thumbprint().unwrap_err();
+            assert!(matches!(err, Web5Error::DataMember(_)));
+            assert_eq!(err.to_string(), "data member error missing y");
+        }
+
+        #[test]
+        fn test_ec_empty_y() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Jwk {
+                kty: "EC".to_string(),
+                crv: "P-256".to_string(),
+                x: "x_value".to_string(),
+                y: Some("".to_string()),
+                ..Default::default()
+            };
+
+            let err = jwk.compute_thumbprint().unwrap_err();
+            assert!(matches!(err, Web5Error::DataMember(_)));
+            assert_eq!(err.to_string(), "data member error y cannot be empty");
+        }
     }
 }

--- a/crates/web5/src/crypto/key_managers/mod.rs
+++ b/crates/web5/src/crypto/key_managers/mod.rs
@@ -1,12 +1,12 @@
+use crate::errors::Web5Error;
+
 pub mod in_memory_key_manager;
 pub mod key_manager;
-
-use crate::crypto::jwk::JwkError;
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum KeyManagerError {
     #[error(transparent)]
-    JwkError(#[from] JwkError),
+    Web5Error(#[from] Web5Error),
     #[error("Key generation failed")]
     KeyGenerationFailed,
     #[error("{0}")]

--- a/crates/web5/src/dids/bearer_did.rs
+++ b/crates/web5/src/dids/bearer_did.rs
@@ -1,5 +1,5 @@
 use super::{
-    data_model::{document::Document, DataModelError as DidDataModelError},
+    data_model::document::Document,
     did::Did,
     portable_did::PortableDid,
     resolution::{
@@ -23,8 +23,6 @@ pub enum BearerDidError {
     Web5Error(#[from] Web5Error),
     #[error(transparent)]
     ResolutionError(#[from] ResolutionMetadataError),
-    #[error(transparent)]
-    DidDataModelError(#[from] DidDataModelError),
     #[error(transparent)]
     KeyManagerError(#[from] KeyManagerError),
 }
@@ -74,7 +72,7 @@ impl BearerDid {
     }
 
     pub fn get_signer(&self, key_id: String) -> Result<Arc<dyn Signer>> {
-        let public_jwk = self.document.find_public_key_jwk(key_id)?;
+        let public_jwk = self.document.find_public_jwk(key_id)?;
         Ok(self.key_manager.get_signer(public_jwk)?)
     }
 }

--- a/crates/web5/src/dids/data_model/document.rs
+++ b/crates/web5/src/dids/data_model/document.rs
@@ -1,5 +1,8 @@
-use super::{service::Service, verification_method::VerificationMethod, Result};
-use crate::crypto::jwk::Jwk;
+use super::{service::Service, verification_method::VerificationMethod};
+use crate::{
+    crypto::jwk::Jwk,
+    errors::{Result, Web5Error},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -34,12 +37,15 @@ pub struct Document {
 }
 
 impl Document {
-    pub fn find_public_key_jwk(&self, key_id: String) -> Result<Jwk> {
+    pub(crate) fn find_public_jwk(&self, key_id: String) -> Result<Jwk> {
         for vm in &self.verification_method {
             if vm.id == key_id {
                 return Ok(vm.public_key_jwk.clone());
             }
         }
-        Err(super::DataModelError::MissingPublicKeyJwk(key_id))
+        Err(Web5Error::NotFound(format!(
+            "jwk not found for key_id {}",
+            key_id
+        )))
     }
 }

--- a/crates/web5/src/dids/data_model/mod.rs
+++ b/crates/web5/src/dids/data_model/mod.rs
@@ -1,11 +1,3 @@
 pub mod document;
 pub mod service;
 pub mod verification_method;
-
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
-pub enum DataModelError {
-    #[error("publicKeyJwk not found {0}")]
-    MissingPublicKeyJwk(String),
-}
-
-type Result<T> = std::result::Result<T, DataModelError>;

--- a/crates/web5/src/dids/methods/did_dht/document_packet/mod.rs
+++ b/crates/web5/src/dids/methods/did_dht/document_packet/mod.rs
@@ -1,6 +1,7 @@
-use crate::crypto::{dsa::DsaError, jwk::JwkError};
+use crate::crypto::dsa::DsaError;
 use crate::dids::data_model::document::Document;
 use crate::dids::data_model::{service::Service, verification_method::VerificationMethod};
+use crate::errors::Web5Error;
 use simple_dns::SimpleDnsError;
 use std::collections::HashMap;
 
@@ -52,7 +53,7 @@ pub enum DocumentPacketError {
     #[error(transparent)]
     Dns(#[from] SimpleDnsError),
     #[error(transparent)]
-    JwkError(#[from] JwkError),
+    Web5Error(#[from] Web5Error),
     #[error("DNS packet was malformed: {0}")]
     RootRecord(String),
     #[error("Could not convert between publicKeyJwk and resource record: {0}")]

--- a/crates/web5/src/dids/portable_did.rs
+++ b/crates/web5/src/dids/portable_did.rs
@@ -1,7 +1,9 @@
 use super::data_model::document::Document;
-use crate::crypto::jwk::Jwk;
+use crate::{
+    crypto::jwk::Jwk,
+    json::{FromJson, ToJson},
+};
 use serde::{Deserialize, Serialize};
-use serde_json::Error as SerdeJsonError;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct PortableDid {
@@ -12,23 +14,5 @@ pub struct PortableDid {
     pub private_jwks: Vec<Jwk>,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum PortableDidError {
-    #[error("serde json error {0}")]
-    SerdeJsonError(String),
-}
-
-impl From<SerdeJsonError> for PortableDidError {
-    fn from(err: SerdeJsonError) -> Self {
-        PortableDidError::SerdeJsonError(err.to_string())
-    }
-}
-
-type Result<T> = std::result::Result<T, PortableDidError>;
-
-impl PortableDid {
-    pub fn new(json: &str) -> Result<Self> {
-        let portable_did = serde_json::from_str::<Self>(json)?;
-        Ok(portable_did)
-    }
-}
+impl FromJson for PortableDid {}
+impl ToJson for PortableDid {}

--- a/crates/web5/src/errors.rs
+++ b/crates/web5/src/errors.rs
@@ -8,6 +8,8 @@ pub enum Web5Error {
     Parameter(String),
     #[error("data member error {0}")]
     DataMember(String),
+    #[error("not found error {0}")]
+    NotFound(String),
 }
 
 impl From<SerdeJsonError> for Web5Error {

--- a/crates/web5/src/errors.rs
+++ b/crates/web5/src/errors.rs
@@ -6,6 +6,8 @@ pub enum Web5Error {
     Json(String),
     #[error("parameter error {0}")]
     Parameter(String),
+    #[error("data member error {0}")]
+    DataMember(String),
 }
 
 impl From<SerdeJsonError> for Web5Error {

--- a/crates/web5_cli/src/vcs.rs
+++ b/crates/web5_cli/src/vcs.rs
@@ -6,7 +6,7 @@ use web5::{
         CredentialSubject, Issuer, VerifiableCredential, VerifiableCredentialCreateOptions,
     },
     dids::{bearer_did::BearerDid, portable_did::PortableDid},
-    json::ToJson,
+    json::{FromJson, ToJson},
 };
 
 #[derive(Subcommand, Debug)]
@@ -44,7 +44,9 @@ impl Commands {
                 no_indent,
                 json_escape,
             } => {
-                let portable_did = portable_did.as_ref().map(|p| PortableDid::new(p).unwrap());
+                let portable_did = portable_did
+                    .as_ref()
+                    .map(|p| PortableDid::from_json_string(p).unwrap());
                 let issuer = Issuer::String(match issuer {
                     Some(i) => i.to_string(),
                     None => match &portable_did {

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -413,9 +413,6 @@ CLASS Document
   ///
   /// [Specification Reference](https://www.w3.org/TR/did-core/#services)
   PUBLIC DATA service: []Service?
-
-  /// Return the Jwk from the Verification Method with the matching key ID.
-  METHOD find_public_jwk_jwk(key_id: string): Jwk
 ```
 
 ### `VerificationMethod`
@@ -698,7 +695,9 @@ CLASS PortableDid
   DATA MEMBER uri: string
   DATA MEMBER private_jwks: []Jwk
   DATA MEMBER document: Document
-  CONSTRUCTOR(json: string)
+  
+  CONSTRUCTOR from_json_string(json: string)
+  METHOD to_json_string(): string
 ```
 
 ### Example: Create a [`PortableDid`](#portabledid) via the `web5` CLI

--- a/tests/unit_test_cases/jwk_compute_thumbprint.json
+++ b/tests/unit_test_cases/jwk_compute_thumbprint.json
@@ -1,0 +1,10 @@
+[
+  "test_ec_valid",
+  "test_okp_valid",
+  "test_unsupported_kty",
+  "test_empty_kty",
+  "test_empty_x",
+  "test_empty_crv",
+  "test_ec_missing_y",
+  "test_ec_empty_y"
+]


### PR DESCRIPTION
- Add comprehensive unit test coverage for JWK's compute thumbprint
- Add compute thumbprint uniffi binding
- Add `ToInner*` and `ToOuter*` for the kt key manager and signer (disintermediates the uniffi code gen)
- Add new `Web5Error:: DataMember` error variant -- signifies a semantic error for a given instances data members (ex. an empty string is a valid `String` type in Rust but semantically invalid)