### PR TITLE
Make Document's find_public_jwk() internal to the crate

### DIFF
--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -208,9 +208,11 @@ dictionary PortableDidData {
 };
 
 interface PortableDid {
-  [Throws=Web5Error]
+  [Name=from_json_string, Throws=Web5Error]
   constructor([ByRef] string json);
   PortableDidData get_data();
+  [Throws=Web5Error]
+  string to_json_string();
 };
 
 dictionary BearerDidData {

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -119,8 +119,6 @@ dictionary ServiceData {
 interface Document {
   constructor(DocumentData data);
   DocumentData get_data();
-  [Throws=Web5Error]
-  JwkData find_public_key_jwk(string key_id);
 };
 
 enum ResolutionMetadataError {

--- a/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
@@ -1,5 +1,4 @@
-use crate::errors::Result;
-use web5::{crypto::jwk::Jwk, dids::data_model::document::Document as InnerDocument};
+use web5::dids::data_model::document::Document as InnerDocument;
 
 pub struct Document(pub InnerDocument);
 
@@ -10,9 +9,5 @@ impl Document {
 
     pub fn get_data(&self) -> InnerDocument {
         self.0.clone()
-    }
-
-    pub fn find_public_key_jwk(&self, key_id: String) -> Result<Jwk> {
-        Ok(self.0.find_public_key_jwk(key_id)?)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/dids/portable_did.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/portable_did.rs
@@ -1,16 +1,23 @@
-use web5::dids::portable_did::PortableDid as InnerPortableDid;
-
 use crate::errors::Result;
+use web5::{
+    dids::portable_did::PortableDid as InnerPortableDid,
+    json::{FromJson, ToJson},
+};
 
 pub struct PortableDid(pub InnerPortableDid);
 
 impl PortableDid {
-    pub fn new(json: &str) -> Result<Self> {
-        let inner_portable_did = InnerPortableDid::new(json)?;
+    pub fn from_json_string(json: &str) -> Result<Self> {
+        let inner_portable_did = InnerPortableDid::from_json_string(json)?;
         Ok(Self(inner_portable_did))
     }
 
     pub fn get_data(&self) -> InnerPortableDid {
         self.0.clone()
+    }
+
+    pub fn to_json_string(&self) -> Result<String> {
+        let json_string = self.0.to_json_string()?;
+        Ok(json_string)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -8,7 +8,6 @@ use web5::crypto::dsa::DsaError;
 use web5::crypto::key_managers::KeyManagerError;
 use web5::dids::bearer_did::BearerDidError;
 use web5::dids::methods::MethodError;
-use web5::dids::portable_did::PortableDidError;
 use web5::errors::Web5Error as InnerWeb5Error;
 
 #[derive(Debug, Error)]
@@ -86,12 +85,6 @@ impl From<KeyManagerError> for Web5Error {
 
 impl From<DsaError> for Web5Error {
     fn from(error: DsaError) -> Self {
-        Web5Error::new(error)
-    }
-}
-
-impl From<PortableDidError> for Web5Error {
-    fn from(error: PortableDidError) -> Self {
         Web5Error::new(error)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -7,7 +7,6 @@ use web5::credentials::CredentialError;
 use web5::crypto::dsa::DsaError;
 use web5::crypto::key_managers::KeyManagerError;
 use web5::dids::bearer_did::BearerDidError;
-use web5::dids::data_model::DataModelError as DidDataModelError;
 use web5::dids::methods::MethodError;
 use web5::dids::portable_did::PortableDidError;
 use web5::errors::Web5Error as InnerWeb5Error;
@@ -111,12 +110,6 @@ impl From<CredentialError> for Web5Error {
 
 impl From<PexError> for Web5Error {
     fn from(error: PexError) -> Self {
-        Web5Error::new(error)
-    }
-}
-
-impl From<DidDataModelError> for Web5Error {
-    fn from(error: DidDataModelError) -> Self {
         Web5Error::new(error)
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
@@ -3,23 +3,34 @@ package web5.sdk.dids
 import web5.sdk.crypto.keys.Jwk
 import web5.sdk.rust.PortableDid as RustCorePortableDid
 
-class PortableDid {
-    val didUri: String
-    val document: Document
-    val privateKeys: List<Jwk>
-
+class PortableDid private constructor(
+    val didUri: String,
+    val document: Document,
+    val privateKeys: List<Jwk>,
     internal val rustCorePortableDid: RustCorePortableDid
-
+) {
     /**
      * Constructs a PortableDid from a JSON string.
      *
      * @param json The JSON string.
      */
-    constructor(json: String) {
-        this.rustCorePortableDid = RustCorePortableDid(json)
+    companion object {
+        fun fromJsonString(json: String): PortableDid {
+            val rustCorePortableDid = RustCorePortableDid.fromJsonString(json)
+            val data = rustCorePortableDid.getData()
+            return PortableDid(
+                data.didUri,
+                data.document,
+                data.privateJwks.map { Jwk.fromRustCoreJwkData(it) },
+                rustCorePortableDid
+            )
+        }
+    }
 
-        this.didUri = rustCorePortableDid.getData().didUri
-        this.document = rustCorePortableDid.getData().document
-        this.privateKeys = rustCorePortableDid.getData().privateJwks.map {Jwk.fromRustCoreJwkData(it) }
+    /**
+     * Serializes a PortableDid to a JSON string.
+     */
+    fun toJsonString(): String {
+        return rustCorePortableDid.toJsonString()
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -884,8 +884,6 @@ internal open class UniffiVTableCallbackInterfaceVerifier(
 
 
 
-
-
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -968,8 +966,6 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_web5_uniffi_fn_constructor_document_new(`data`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
-    fun uniffi_web5_uniffi_fn_method_document_find_public_key_jwk(`ptr`: Pointer,`keyId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_method_document_get_data(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_clone_ed25519signer(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -1212,8 +1208,6 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_method_didweb_get_data(
     ): Short
-    fun uniffi_web5_uniffi_checksum_method_document_find_public_key_jwk(
-    ): Short
     fun uniffi_web5_uniffi_checksum_method_document_get_data(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_ed25519signer_sign(
@@ -1333,9 +1327,6 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_method_didweb_get_data() != 40916.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_web5_uniffi_checksum_method_document_find_public_key_jwk() != 16969.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_method_document_get_data() != 16490.toShort()) {
@@ -3113,8 +3104,6 @@ public object FfiConverterTypeDidWeb: FfiConverter<DidWeb, Pointer> {
 
 public interface DocumentInterface {
     
-    fun `findPublicKeyJwk`(`keyId`: kotlin.String): JwkData
-    
     fun `getData`(): DocumentData
     
     companion object
@@ -3207,19 +3196,6 @@ open class Document: Disposable, AutoCloseable, DocumentInterface {
             UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_clone_document(pointer!!, status)
         }
     }
-
-    
-    @Throws(Web5Exception::class)override fun `findPublicKeyJwk`(`keyId`: kotlin.String): JwkData {
-            return FfiConverterTypeJwkData.lift(
-    callWithPointer {
-    uniffiRustCallWithError(Web5Exception) { _status ->
-    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_document_find_public_key_jwk(
-        it, FfiConverterString.lower(`keyId`),_status)
-}
-    }
-    )
-    }
-    
 
     override fun `getData`(): DocumentData {
             return FfiConverterTypeDocumentData.lift(

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -884,6 +884,8 @@ internal open class UniffiVTableCallbackInterfaceVerifier(
 
 
 
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -1018,9 +1020,11 @@ internal interface UniffiLib : Library {
     ): Pointer
     fun uniffi_web5_uniffi_fn_free_portabledid(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
-    fun uniffi_web5_uniffi_fn_constructor_portabledid_new(`json`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    fun uniffi_web5_uniffi_fn_constructor_portabledid_from_json_string(`json`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_web5_uniffi_fn_method_portabledid_get_data(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    fun uniffi_web5_uniffi_fn_method_portabledid_to_json_string(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_clone_presentationdefinition(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
@@ -1228,6 +1232,8 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_method_portabledid_get_data(
     ): Short
+    fun uniffi_web5_uniffi_checksum_method_portabledid_to_json_string(
+    ): Short
     fun uniffi_web5_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_presentationdefinition_select_credentials(
@@ -1268,7 +1274,7 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_jwk_new(
     ): Short
-    fun uniffi_web5_uniffi_checksum_constructor_portabledid_new(
+    fun uniffi_web5_uniffi_checksum_constructor_portabledid_from_json_string(
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_presentationdefinition_new(
     ): Short
@@ -1359,6 +1365,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_method_portabledid_get_data() != 27045.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_web5_uniffi_checksum_method_portabledid_to_json_string() != 53673.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_web5_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition() != 52261.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1419,7 +1428,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_constructor_jwk_new() != 59888.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_web5_uniffi_checksum_constructor_portabledid_new() != 37852.toShort()) {
+    if (lib.uniffi_web5_uniffi_checksum_constructor_portabledid_from_json_string() != 64165.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_constructor_presentationdefinition_new() != 13282.toShort()) {
@@ -4649,6 +4658,8 @@ public interface PortableDidInterface {
     
     fun `getData`(): PortableDidData
     
+    fun `toJsonString`(): kotlin.String
+    
     companion object
 }
 
@@ -4669,13 +4680,6 @@ open class PortableDid: Disposable, AutoCloseable, PortableDidInterface {
         this.pointer = null
         this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
     }
-    constructor(`json`: kotlin.String) :
-        this(
-    uniffiRustCallWithError(Web5Exception) { _status ->
-    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_constructor_portabledid_new(
-        FfiConverterString.lower(`json`),_status)
-}
-    )
 
     protected val pointer: Pointer?
     protected val cleanable: UniffiCleaner.Cleanable
@@ -4753,10 +4757,35 @@ open class PortableDid: Disposable, AutoCloseable, PortableDidInterface {
     
 
     
+    @Throws(Web5Exception::class)override fun `toJsonString`(): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_portabledid_to_json_string(
+        it, _status)
+}
+    }
+    )
+    }
+    
 
     
+
     
-    companion object
+    companion object {
+        
+    @Throws(Web5Exception::class) fun `fromJsonString`(`json`: kotlin.String): PortableDid {
+            return FfiConverterTypePortableDid.lift(
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_constructor_portabledid_from_json_string(
+        FfiConverterString.lower(`json`),_status)
+}
+    )
+    }
+    
+
+        
+    }
     
 }
 

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/PortableDidTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/PortableDidTest.kt
@@ -14,7 +14,7 @@ class PortableDidTest {
         """.trimIndent()
 
         assertDoesNotThrow {
-            val portableDid = PortableDid(jsonString)
+            val portableDid = PortableDid.fromJsonString(jsonString)
             assertEquals("did:web:tbd.website%3A9002:alice", portableDid.didUri)
         }
     }
@@ -23,7 +23,20 @@ class PortableDidTest {
     fun `instantiation from json string throws with invalid json string`() {
         val invalidJsonString = "something not valid"
         assertThrows(Web5Exception::class.java) {
-            PortableDid(invalidJsonString)
+            PortableDid.fromJsonString(invalidJsonString)
+        }
+    }
+
+    @Test
+    fun `can serialize to a json string`() {
+        val jsonString = """
+            {"uri":"did:web:tbd.website%3A9002:alice","document":{"id":"did:web:tbd.website%3A9002:alice","@context":["https://www.w3.org/ns/did/v1"],"verificationMethod":[{"id":"did:web:tbd.website%3A9002:alice#key-0","type":"JsonWebKey","controller":"did:web:tbd.website%3A9002:alice","publicKeyJwk":{"alg":"Ed25519","kty":"OKP","crv":"Ed25519","x":"NNoVSv_v34ombmylF572t9HYYDiJtMgfckRT1W0vW0g"}}]},"privateKeys":[{"alg":"Ed25519","kty":"OKP","crv":"Ed25519","d":"SwuWbL-Fm64OUFy6x3FBt3RiB79RcnZZrllGT24m4BA","x":"NNoVSv_v34ombmylF572t9HYYDiJtMgfckRT1W0vW0g"}]}
+        """.trimIndent()
+
+        assertDoesNotThrow {
+            val portableDid = PortableDid.fromJsonString(jsonString)
+            val serializedJsonString = portableDid.toJsonString()
+            assertEquals(jsonString, serializedJsonString)
         }
     }
 }

--- a/crates/web5/src/credentials/mod.rs
+++ b/crates/web5/src/credentials/mod.rs
@@ -6,8 +6,7 @@ use serde_json::Error as SerdeJsonError;
 use crate::errors::Web5Error;
 
 use super::dids::{
-    bearer_did::BearerDidError, data_model::DataModelError,
-    resolution::resolution_metadata::ResolutionMetadataError,
+    bearer_did::BearerDidError, resolution::resolution_metadata::ResolutionMetadataError,
 };
 
 pub mod presentation_definition;
@@ -37,8 +36,6 @@ pub enum CredentialError {
     MissingKid,
     #[error(transparent)]
     Resolution(#[from] ResolutionMetadataError),
-    #[error(transparent)]
-    DidDataModel(#[from] DataModelError),
     #[error(transparent)]
     Web5Error(#[from] Web5Error),
     #[error(transparent)]

--- a/crates/web5/src/credentials/verifiable_credential_1_1.rs
+++ b/crates/web5/src/credentials/verifiable_credential_1_1.rs
@@ -266,7 +266,7 @@ impl VerifiableCredential {
             .ok_or_else(|| {
                 JosekitError::InvalidJwtFormat(ResolutionMetadataError::InternalError.into())
             })?
-            .find_public_key_jwk(kid.to_string())?;
+            .find_public_jwk(kid.to_string())?;
 
         let verifier = Ed25519Verifier::new(public_key_jwk);
 

--- a/crates/web5/src/dids/bearer_did.rs
+++ b/crates/web5/src/dids/bearer_did.rs
@@ -1,5 +1,5 @@
 use super::{
-    data_model::{document::Document, DataModelError as DidDataModelError},
+    data_model::document::Document,
     did::Did,
     portable_did::PortableDid,
     resolution::{
@@ -23,8 +23,6 @@ pub enum BearerDidError {
     Web5Error(#[from] Web5Error),
     #[error(transparent)]
     ResolutionError(#[from] ResolutionMetadataError),
-    #[error(transparent)]
-    DidDataModelError(#[from] DidDataModelError),
     #[error(transparent)]
     KeyManagerError(#[from] KeyManagerError),
 }
@@ -74,7 +72,7 @@ impl BearerDid {
     }
 
     pub fn get_signer(&self, key_id: String) -> Result<Arc<dyn Signer>> {
-        let public_jwk = self.document.find_public_key_jwk(key_id)?;
+        let public_jwk = self.document.find_public_jwk(key_id)?;
         Ok(self.key_manager.get_signer(public_jwk)?)
     }
 }

--- a/crates/web5/src/dids/data_model/document.rs
+++ b/crates/web5/src/dids/data_model/document.rs
@@ -1,5 +1,8 @@
-use super::{service::Service, verification_method::VerificationMethod, Result};
-use crate::crypto::jwk::Jwk;
+use super::{service::Service, verification_method::VerificationMethod};
+use crate::{
+    crypto::jwk::Jwk,
+    errors::{Result, Web5Error},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -34,12 +37,15 @@ pub struct Document {
 }
 
 impl Document {
-    pub fn find_public_key_jwk(&self, key_id: String) -> Result<Jwk> {
+    pub(crate) fn find_public_jwk(&self, key_id: String) -> Result<Jwk> {
         for vm in &self.verification_method {
             if vm.id == key_id {
                 return Ok(vm.public_key_jwk.clone());
             }
         }
-        Err(super::DataModelError::MissingPublicKeyJwk(key_id))
+        Err(Web5Error::NotFound(format!(
+            "jwk not found for key_id {}",
+            key_id
+        )))
     }
 }

--- a/crates/web5/src/dids/data_model/mod.rs
+++ b/crates/web5/src/dids/data_model/mod.rs
@@ -1,11 +1,3 @@
 pub mod document;
 pub mod service;
 pub mod verification_method;
-
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
-pub enum DataModelError {
-    #[error("publicKeyJwk not found {0}")]
-    MissingPublicKeyJwk(String),
-}
-
-type Result<T> = std::result::Result<T, DataModelError>;

--- a/crates/web5/src/dids/portable_did.rs
+++ b/crates/web5/src/dids/portable_did.rs
@@ -1,7 +1,9 @@
 use super::data_model::document::Document;
-use crate::crypto::jwk::Jwk;
+use crate::{
+    crypto::jwk::Jwk,
+    json::{FromJson, ToJson},
+};
 use serde::{Deserialize, Serialize};
-use serde_json::Error as SerdeJsonError;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct PortableDid {
@@ -12,23 +14,5 @@ pub struct PortableDid {
     pub private_jwks: Vec<Jwk>,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum PortableDidError {
-    #[error("serde json error {0}")]
-    SerdeJsonError(String),
-}
-
-impl From<SerdeJsonError> for PortableDidError {
-    fn from(err: SerdeJsonError) -> Self {
-        PortableDidError::SerdeJsonError(err.to_string())
-    }
-}
-
-type Result<T> = std::result::Result<T, PortableDidError>;
-
-impl PortableDid {
-    pub fn new(json: &str) -> Result<Self> {
-        let portable_did = serde_json::from_str::<Self>(json)?;
-        Ok(portable_did)
-    }
-}
+impl FromJson for PortableDid {}
+impl ToJson for PortableDid {}

--- a/crates/web5/src/errors.rs
+++ b/crates/web5/src/errors.rs
@@ -8,6 +8,8 @@ pub enum Web5Error {
     Parameter(String),
     #[error("data member error {0}")]
     DataMember(String),
+    #[error("not found error {0}")]
+    NotFound(String),
 }
 
 impl From<SerdeJsonError> for Web5Error {

--- a/crates/web5_cli/src/vcs.rs
+++ b/crates/web5_cli/src/vcs.rs
@@ -6,7 +6,7 @@ use web5::{
         CredentialSubject, Issuer, VerifiableCredential, VerifiableCredentialCreateOptions,
     },
     dids::{bearer_did::BearerDid, portable_did::PortableDid},
-    json::ToJson,
+    json::{FromJson, ToJson},
 };
 
 #[derive(Subcommand, Debug)]
@@ -44,7 +44,9 @@ impl Commands {
                 no_indent,
                 json_escape,
             } => {
-                let portable_did = portable_did.as_ref().map(|p| PortableDid::new(p).unwrap());
+                let portable_did = portable_did
+                    .as_ref()
+                    .map(|p| PortableDid::from_json_string(p).unwrap());
                 let issuer = Issuer::String(match issuer {
                     Some(i) => i.to_string(),
                     None => match &portable_did {

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -695,7 +695,9 @@ CLASS PortableDid
   DATA MEMBER uri: string
   DATA MEMBER private_jwks: []Jwk
   DATA MEMBER document: Document
-  CONSTRUCTOR(json: string)
+  
+  CONSTRUCTOR from_json_string(json: string)
+  METHOD to_json_string(): string
 ```
 
 ### Example: Create a [`PortableDid`](#portabledid) via the `web5` CLI

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -413,9 +413,6 @@ CLASS Document
   ///
   /// [Specification Reference](https://www.w3.org/TR/did-core/#services)
   PUBLIC DATA service: []Service?
-
-  /// Return the Jwk from the Verification Method with the matching key ID.
-  METHOD find_public_jwk_jwk(key_id: string): Jwk
 ```
 
 ### `VerificationMethod`


### PR DESCRIPTION
Remove `find_public_jwk_jwk` (misspelled in the APID) from the APID, maintain it but keep it internal to the crate. We'll probably want a mechanism to standardize whatever the `key_id` is, but that can come later.

Also add new `Web5Error:NotFound` variant which signifies the given resource is not found -- embrace debate if you disagree with this error variant being added to our standard error type.