### PR TITLE
Use error for Verifier::verify(), Add ed25519 unit tests, Add Web5Error::Crypto

### DIFF
--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -57,7 +57,7 @@ interface Signer {
 [Trait, WithForeign]
 interface Verifier {
   [Throws=Web5Error]
-  boolean verify(bytes message, bytes signature);
+  void verify(bytes message, bytes signature);
 };
 
 interface Ed25519Signer {
@@ -69,7 +69,7 @@ interface Ed25519Signer {
 interface Ed25519Verifier {
   constructor(JwkData public_jwk);
   [Throws=Web5Error]
-  boolean verify(bytes message, bytes signature);
+  void verify(bytes message, bytes signature);
 };
 
 dictionary DidData {

--- a/bindings/web5_uniffi_wrapper/src/crypto/dsa/ed25519.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/dsa/ed25519.rs
@@ -38,7 +38,7 @@ impl Ed25519Verifier {
 }
 
 impl Verifier for Ed25519Verifier {
-    fn verify(&self, payload: Vec<u8>, signature: Vec<u8>) -> Result<bool> {
+    fn verify(&self, payload: Vec<u8>, signature: Vec<u8>) -> Result<()> {
         Ok(self.0.verify(&payload, &signature)?)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/crypto/dsa/mod.rs
+++ b/bindings/web5_uniffi_wrapper/src/crypto/dsa/mod.rs
@@ -19,21 +19,20 @@ impl Signer for ToOuterSigner {
 pub struct ToInnerSigner(pub Arc<dyn Signer>);
 
 impl InnerSigner for ToInnerSigner {
-    fn sign(&self, payload: &[u8]) -> web5::crypto::dsa::Result<Vec<u8>> {
+    fn sign(&self, payload: &[u8]) -> web5::errors::Result<Vec<u8>> {
         let signature = self.0.sign(Vec::from(payload))?;
         Ok(signature)
     }
 }
 
 pub trait Verifier: Send + Sync {
-    fn verify(&self, payload: Vec<u8>, signature: Vec<u8>) -> Result<bool>;
+    fn verify(&self, payload: Vec<u8>, signature: Vec<u8>) -> Result<()>;
 }
 
 pub struct ToInnerVerifier(pub Arc<dyn Verifier>);
 
 impl InnerVerifier for ToInnerVerifier {
-    fn verify(&self, payload: &[u8], signature: &[u8]) -> web5::crypto::dsa::Result<bool> {
-        let verified = self.0.verify(Vec::from(payload), Vec::from(signature))?;
-        Ok(verified)
+    fn verify(&self, payload: &[u8], signature: &[u8]) -> web5::errors::Result<()> {
+        Ok(self.0.verify(Vec::from(payload), Vec::from(signature))?)
     }
 }

--- a/bindings/web5_uniffi_wrapper/src/errors.rs
+++ b/bindings/web5_uniffi_wrapper/src/errors.rs
@@ -4,7 +4,6 @@ use std::{any::type_name, fmt::Debug};
 use thiserror::Error;
 use web5::credentials::presentation_definition::PexError;
 use web5::credentials::CredentialError;
-use web5::crypto::dsa::DsaError;
 use web5::crypto::key_managers::KeyManagerError;
 use web5::dids::bearer_did::BearerDidError;
 use web5::dids::methods::MethodError;
@@ -83,12 +82,6 @@ impl From<KeyManagerError> for Web5Error {
     }
 }
 
-impl From<DsaError> for Web5Error {
-    fn from(error: DsaError) -> Self {
-        Web5Error::new(error)
-    }
-}
-
 impl From<MethodError> for Web5Error {
     fn from(error: MethodError) -> Self {
         Web5Error::new(error)
@@ -138,32 +131,26 @@ impl From<Web5Error> for KeyManagerError {
     }
 }
 
-impl From<Web5Error> for DsaError {
+impl From<Web5Error> for InnerWeb5Error {
     fn from(error: Web5Error) -> Self {
         let variant = error.variant();
         let msg = error.msg();
 
-        if variant == variant_name(&DsaError::MissingPrivateKey) {
-            return DsaError::MissingPrivateKey;
-        } else if variant == variant_name(&DsaError::DecodeError(String::default())) {
-            return DsaError::DecodeError(msg);
-        } else if variant == variant_name(&DsaError::InvalidKeyLength(String::default())) {
-            return DsaError::InvalidKeyLength(msg);
-        } else if variant == variant_name(&DsaError::InvalidSignatureLength(String::default())) {
-            return DsaError::InvalidSignatureLength(msg);
-        } else if variant == variant_name(&DsaError::PublicKeyFailure(String::default())) {
-            return DsaError::PublicKeyFailure(msg);
-        } else if variant == variant_name(&DsaError::PrivateKeyFailure(String::default())) {
-            return DsaError::PrivateKeyFailure(msg);
-        } else if variant == variant_name(&DsaError::VerificationFailure(String::default())) {
-            return DsaError::VerificationFailure(msg);
-        } else if variant == variant_name(&DsaError::SignFailure(String::default())) {
-            return DsaError::SignFailure(msg);
-        } else if variant == variant_name(&DsaError::UnsupportedDsa) {
-            return DsaError::UnsupportedDsa;
+        if variant == variant_name(&InnerWeb5Error::Json(String::default())) {
+            return InnerWeb5Error::Json(msg);
+        } else if variant == variant_name(&InnerWeb5Error::Parameter(String::default())) {
+            return InnerWeb5Error::Parameter(msg);
+        } else if variant == variant_name(&InnerWeb5Error::DataMember(String::default())) {
+            return InnerWeb5Error::DataMember(msg);
+        } else if variant == variant_name(&InnerWeb5Error::NotFound(String::default())) {
+            return InnerWeb5Error::NotFound(msg);
+        } else if variant == variant_name(&InnerWeb5Error::Crypto(String::default())) {
+            return InnerWeb5Error::Crypto(msg);
+        } else if variant == variant_name(&InnerWeb5Error::Encoding(String::default())) {
+            return InnerWeb5Error::Encoding(msg);
         }
 
-        DsaError::Unknown
+        InnerWeb5Error::Unknown(format!("unknown variant {} with msg {}", variant, msg))
     }
 }
 

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/Ed25519Generator.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/Ed25519Generator.kt
@@ -1,0 +1,21 @@
+package web5.sdk.crypto
+
+import web5.sdk.crypto.keys.Jwk
+import web5.sdk.rust.ed25519GeneratorGenerate
+
+/**
+ * Generates private key material for Ed25519.
+ */
+class Ed25519Generator {
+    companion object {
+        /**
+         * Generate the private key material; return Jwk includes private key material.
+         *
+         * @return Jwk the JWK with private key material included.
+         */
+        fun generate(): Jwk {
+            val rustCoreJwkData = ed25519GeneratorGenerate()
+            return Jwk.fromRustCoreJwkData(rustCoreJwkData)
+        }
+    }
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Ed25519Signer.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Ed25519Signer.kt
@@ -3,16 +3,11 @@ package web5.sdk.crypto.signers
 import web5.sdk.crypto.keys.Jwk
 import web5.sdk.rust.Ed25519Signer as RustCoreEd25519Signer
 
-class Ed25519Signer : Signer {
-    private val rustCoreSigner: RustCoreEd25519Signer
-
-    constructor(privateKey: Jwk) {
-        this.rustCoreSigner = RustCoreEd25519Signer(privateKey.rustCoreJwkData)
-    }
-
-    private constructor(rustCoreSigner: RustCoreEd25519Signer) {
-        this.rustCoreSigner = rustCoreSigner
-    }
+/**
+ * Implementation of Signer for Ed25519.
+ */
+class Ed25519Signer(privateJwk: Jwk) : Signer {
+    private val rustCoreSigner = RustCoreEd25519Signer(privateJwk.rustCoreJwkData)
 
     /**
      * Implementation of Signer's sign instance method for Ed25519.

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Signer.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/signers/Signer.kt
@@ -2,7 +2,16 @@ package web5.sdk.crypto.signers
 
 import web5.sdk.rust.Signer as RustCoreSigner
 
+/**
+ * Set of functionality required to implement to be a compatible DSA signer.
+ */
 interface Signer {
+    /**
+     * Signs the given payload by using the encapsulated private key material.
+     *
+     * @param payload the data to be signed.
+     * @return ByteArray the signature.
+     */
     fun sign(payload: ByteArray): ByteArray
 }
 

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/verifiers/Ed25519Verifier.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/verifiers/Ed25519Verifier.kt
@@ -2,26 +2,22 @@ package web5.sdk.crypto.verifiers
 
 import web5.sdk.crypto.keys.Jwk
 import web5.sdk.rust.Ed25519Verifier as RustCoreEd25519Verifier
+import web5.sdk.rust.Web5Exception
 
-class Ed25519Verifier : Verifier {
-    private val rustCoreVerifier: RustCoreEd25519Verifier
-
-    constructor(privateKey: Jwk) {
-        this.rustCoreVerifier = RustCoreEd25519Verifier(privateKey.rustCoreJwkData)
-    }
-
-    private constructor(rustCoreVerifier: RustCoreEd25519Verifier) {
-        this.rustCoreVerifier = rustCoreVerifier
-    }
+/**
+ * Implementation of Verifier for Ed25519.
+ */
+class Ed25519Verifier(publicJwk: Jwk) : Verifier {
+    private val rustCoreVerifier = RustCoreEd25519Verifier(publicJwk.rustCoreJwkData)
 
     /**
      * Implementation of Signer's verify instance method for Ed25519.
      *
      * @param message the data to be verified.
      * @param signature the signature to be verified.
-     * @return ByteArray the signature.
+     * @throws Web5Exception in the case of a failed verification
      */
-    override fun verify(message: ByteArray, signature: ByteArray): Boolean {
-        return rustCoreVerifier.verify(message, signature);
+    override fun verify(message: ByteArray, signature: ByteArray) {
+        rustCoreVerifier.verify(message, signature)
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/verifiers/Verifier.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/verifiers/Verifier.kt
@@ -1,5 +1,30 @@
 package web5.sdk.crypto.verifiers
 
 import web5.sdk.rust.Verifier as RustCoreVerifier
+import web5.sdk.rust.Web5Exception
 
-typealias Verifier = RustCoreVerifier
+/**
+ * Set of functionality required to implement to be a compatible DSA verifier.
+ */
+interface Verifier {
+    /**
+     * Execute the verification of the signature against the payload by using the encapsulated public key material.
+     *
+     * @param message the data which was signed over.
+     * @param signature the signature over the message.
+     * @throws Web5Exception in the case of a failed verification.
+     */
+    fun verify(message: ByteArray, signature: ByteArray)
+}
+
+internal class ToOuterVerifier(private val rustCoreVerifier: RustCoreVerifier) : Verifier {
+    override fun verify(message: ByteArray, signature: ByteArray) {
+        rustCoreVerifier.verify(message, signature)
+    }
+}
+
+internal class ToInnerVerifier(private val verifier: Verifier) : RustCoreVerifier {
+    override fun verify(message: ByteArray, signature: ByteArray) {
+        verifier.verify(message, signature)
+    }
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -647,7 +647,7 @@ internal interface UniffiCallbackInterfaceSignerMethod0 : com.sun.jna.Callback {
     fun callback(`uniffiHandle`: Long,`payload`: RustBuffer.ByValue,`uniffiOutReturn`: RustBuffer,uniffiCallStatus: UniffiRustCallStatus,)
 }
 internal interface UniffiCallbackInterfaceVerifierMethod0 : com.sun.jna.Callback {
-    fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`signature`: RustBuffer.ByValue,`uniffiOutReturn`: ByteByReference,uniffiCallStatus: UniffiRustCallStatus,)
+    fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`signature`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
 }
 @Structure.FieldOrder("getSigner", "uniffiFree")
 internal open class UniffiVTableCallbackInterfaceKeyManager(
@@ -985,7 +985,7 @@ internal interface UniffiLib : Library {
     fun uniffi_web5_uniffi_fn_constructor_ed25519verifier_new(`publicJwk`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_web5_uniffi_fn_method_ed25519verifier_verify(`ptr`: Pointer,`message`: RustBuffer.ByValue,`signature`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): Byte
+    ): Unit
     fun uniffi_web5_uniffi_fn_clone_inmemorykeymanager(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_web5_uniffi_fn_free_inmemorykeymanager(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -1067,7 +1067,7 @@ internal interface UniffiLib : Library {
     fun uniffi_web5_uniffi_fn_init_callback_vtable_verifier(`vtable`: UniffiVTableCallbackInterfaceVerifier,
     ): Unit
     fun uniffi_web5_uniffi_fn_method_verifier_verify(`ptr`: Pointer,`message`: RustBuffer.ByValue,`signature`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): Byte
+    ): Unit
     fun uniffi_web5_uniffi_fn_func_did_dht_resolve(`uri`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_web5_uniffi_fn_func_did_jwk_resolve(`uri`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1341,7 +1341,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_method_ed25519signer_sign() != 7079.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_web5_uniffi_checksum_method_ed25519verifier_verify() != 48256.toShort()) {
+    if (lib.uniffi_web5_uniffi_checksum_method_ed25519verifier_verify() != 54498.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_method_inmemorykeymanager_get_as_key_manager() != 57819.toShort()) {
@@ -1383,7 +1383,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_method_verifiablecredential_get_data() != 34047.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_web5_uniffi_checksum_method_verifier_verify() != 49443.toShort()) {
+    if (lib.uniffi_web5_uniffi_checksum_method_verifier_verify() != 51688.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_constructor_bearerdid_from_portable_did() != 49122.toShort()) {
@@ -3592,7 +3592,7 @@ public object FfiConverterTypeEd25519Signer: FfiConverter<Ed25519Signer, Pointer
 
 public interface Ed25519VerifierInterface {
     
-    fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray): kotlin.Boolean
+    fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray)
     
     companion object
 }
@@ -3686,16 +3686,15 @@ open class Ed25519Verifier: Disposable, AutoCloseable, Ed25519VerifierInterface 
     }
 
     
-    @Throws(Web5Exception::class)override fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray): kotlin.Boolean {
-            return FfiConverterBoolean.lift(
+    @Throws(Web5Exception::class)override fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray)
+        = 
     callWithPointer {
     uniffiRustCallWithError(Web5Exception) { _status ->
     UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_ed25519verifier_verify(
         it, FfiConverterByteArray.lower(`message`),FfiConverterByteArray.lower(`signature`),_status)
 }
     }
-    )
-    }
+    
     
 
     
@@ -5926,7 +5925,7 @@ public object FfiConverterTypeVerifiableCredential: FfiConverter<VerifiableCrede
 
 public interface Verifier {
     
-    fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray): kotlin.Boolean
+    fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray)
     
     companion object
 }
@@ -6013,16 +6012,15 @@ open class VerifierImpl: Disposable, AutoCloseable, Verifier {
     }
 
     
-    @Throws(Web5Exception::class)override fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray): kotlin.Boolean {
-            return FfiConverterBoolean.lift(
+    @Throws(Web5Exception::class)override fun `verify`(`message`: kotlin.ByteArray, `signature`: kotlin.ByteArray)
+        = 
     callWithPointer {
     uniffiRustCallWithError(Web5Exception) { _status ->
     UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_verifier_verify(
         it, FfiConverterByteArray.lower(`message`),FfiConverterByteArray.lower(`signature`),_status)
 }
     }
-    )
-    }
+    
     
 
     
@@ -6037,7 +6035,7 @@ open class VerifierImpl: Disposable, AutoCloseable, Verifier {
 // Put the implementation in an object so we don't pollute the top-level namespace
 internal object uniffiCallbackInterfaceVerifier {
     internal object `verify`: UniffiCallbackInterfaceVerifierMethod0 {
-        override fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`signature`: RustBuffer.ByValue,`uniffiOutReturn`: ByteByReference,uniffiCallStatus: UniffiRustCallStatus,) {
+        override fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`signature`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,) {
             val uniffiObj = FfiConverterTypeVerifier.handleMap.get(uniffiHandle)
             val makeCall = { ->
                 uniffiObj.`verify`(
@@ -6045,7 +6043,7 @@ internal object uniffiCallbackInterfaceVerifier {
                     FfiConverterByteArray.lift(`signature`),
                 )
             }
-            val writeReturn = { value: kotlin.Boolean -> uniffiOutReturn.setValue(FfiConverterBoolean.lower(value)) }
+            val writeReturn = { _: Unit -> Unit }
             uniffiTraitInterfaceCallWithError(
                 uniffiCallStatus,
                 makeCall,

--- a/bound/kt/src/test/kotlin/web5/sdk/Web5TestVectorsTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/Web5TestVectorsTest.kt
@@ -21,6 +21,7 @@ import web5.sdk.crypto.verifiers.Ed25519Verifier
 import web5.sdk.dids.Document
 import web5.sdk.rust.DocumentMetadataData
 import web5.sdk.rust.ResolutionMetadataData
+import web5.sdk.rust.Web5Exception
 
 class Web5TestVectorsTest {
 
@@ -110,20 +111,21 @@ class Web5TestVectorsTest {
                 val ed25519Jwk = Jwk(
                     kty = testVectorJwk.kty,
                     crv = testVectorJwk.crv,
-                    d = null,
+                    d = testVectorJwk.d,
                     x = testVectorJwk.x,
                     alg = null,
                     y = null
                 )
                 val verifier = Ed25519Verifier(ed25519Jwk)
 
-                if (vector.errors == true) {
-                    assertThrows(Exception::class.java) {
+                if (vector.errors == true || vector.output == false) {
+                    assertThrows(Web5Exception.Exception::class.java) {
                         verifier.verify(inputByteArray, signatureByteArray)
                     }
                 } else {
-                    val verified = verifier.verify(inputByteArray, signatureByteArray)
-                    assertEquals(vector.output, verified)
+                    assertDoesNotThrow {
+                        verifier.verify(inputByteArray, signatureByteArray)
+                    }
                 }
             }
         }

--- a/bound/kt/src/test/kotlin/web5/sdk/crypto/Ed25519GeneratorTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/crypto/Ed25519GeneratorTest.kt
@@ -1,0 +1,69 @@
+package web5.sdk.crypto
+
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.fail
+import web5.sdk.UnitTestSuite
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Ed25519GeneratorTest {
+
+    private val testSuite = UnitTestSuite("ed25519_generate")
+
+    @AfterAll
+    fun verifyAllTestsIncluded() {
+        if (testSuite.tests.isNotEmpty()) {
+            println("The following tests were not included or executed:")
+            testSuite.tests.forEach { println(it) }
+            fail("Not all tests were executed! ${this.testSuite.tests}")
+        }
+    }
+
+    @Test
+    fun test_must_set_alg() {
+        this.testSuite.include()
+
+        val jwk = Ed25519Generator.generate()
+        assertEquals("Ed25519", jwk.alg)
+    }
+
+    @Test
+    fun test_must_set_kty() {
+        this.testSuite.include()
+
+        val jwk = Ed25519Generator.generate()
+        assertEquals("OKP", jwk.kty)
+    }
+
+    @Test
+    fun test_must_set_crv() {
+        this.testSuite.include()
+
+        val jwk = Ed25519Generator.generate()
+        assertEquals("Ed25519", jwk.crv)
+    }
+
+    @Test
+    fun test_must_set_public_key_with_correct_length() {
+        this.testSuite.include()
+
+        val jwk = Ed25519Generator.generate()
+        val publicKeyBytes = java.util.Base64.getUrlDecoder().decode(jwk.x)
+        assertEquals(PUBLIC_KEY_LENGTH, publicKeyBytes.size)
+    }
+
+    @Test
+    fun test_must_set_private_key_with_correct_length() {
+        this.testSuite.include()
+
+        val jwk = Ed25519Generator.generate()
+        val privateKeyBytes = jwk.d ?: fail("Private key is missing")
+        val decodedPrivateKeyBytes = java.util.Base64.getUrlDecoder().decode(privateKeyBytes)
+        assertEquals(SECRET_KEY_LENGTH, decodedPrivateKeyBytes.size)
+    }
+
+    companion object {
+        const val PUBLIC_KEY_LENGTH = 32
+        const val SECRET_KEY_LENGTH = 32
+    }
+}

--- a/bound/kt/src/test/kotlin/web5/sdk/crypto/signers/Ed25519SignerTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/crypto/signers/Ed25519SignerTest.kt
@@ -1,34 +1,77 @@
 package web5.sdk.crypto.signers
 
-import org.junit.jupiter.api.Test
-import web5.sdk.crypto.keys.InMemoryKeyManager
-import org.junit.jupiter.api.Assertions.assertNotNull
-import web5.sdk.crypto.keys.Jwk
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.fail
+import web5.sdk.UnitTestSuite
+import web5.sdk.crypto.Ed25519Generator
+import web5.sdk.rust.Web5Exception
 
-import web5.sdk.rust.ed25519GeneratorGenerate as rustCoreEd25519GeneratorGenerate
-
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Ed25519SignerTest {
 
-    @Test
-    fun `test signer`() {
-        val rustCorePrivateJwk = rustCoreEd25519GeneratorGenerate()
-        val ed25519Signer = Ed25519Signer(Jwk.fromRustCoreJwkData(rustCorePrivateJwk))
+    private val testSuite = UnitTestSuite("ed25519_sign")
 
-        val payload = ed25519Signer.sign("abc".toByteArray())
-
-        assertNotNull(payload)
+    @AfterAll
+    fun verifyAllTestsIncluded() {
+        if (testSuite.tests.isNotEmpty()) {
+            println("The following tests were not included or executed:")
+            testSuite.tests.forEach { println(it) }
+            fail("Not all tests were executed! ${this.testSuite.tests}")
+        }
     }
 
     @Test
-    fun `test signer with key manager`() {
-        val privateJwk = rustCoreEd25519GeneratorGenerate()
+    fun test_with_valid_key() {
+        this.testSuite.include()
 
-        val keyManager = InMemoryKeyManager(listOf())
-        val publicJwk = keyManager.importPrivateJwk(Jwk.fromRustCoreJwkData(privateJwk))
+        val jwk = Ed25519Generator.generate()
+        val signer = Ed25519Signer(jwk)
 
-        val ed25519Signer = keyManager.getSigner(publicJwk)
-        val payload = ed25519Signer.sign("abc".toByteArray())
+        val message = "Test message".toByteArray()
 
-        assertNotNull(payload)
+        assertDoesNotThrow {
+            val signature = signer.sign(message)
+            assertEquals(SIGNATURE_LENGTH, signature.size, "Signature length should match the expected Ed25519 signature length")
+        }
+    }
+
+    @Test
+    fun test_with_invalid_private_key() {
+        this.testSuite.include()
+
+        val jwk = Ed25519Generator.generate()
+        val invalidJwk = jwk.copy(d = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(ByteArray(SECRET_KEY_LENGTH - 1)))
+
+        val signer = Ed25519Signer(invalidJwk)
+        val message = "Test message".toByteArray()
+        val exception = assertThrows<Web5Exception.Exception> {
+            signer.sign(message)
+        }
+
+        assertEquals("cryptography error invalid private key length ${SECRET_KEY_LENGTH - 1} must be $SECRET_KEY_LENGTH", exception.msg)
+        assertEquals("Crypto", exception.variant)
+    }
+
+    @Test
+    fun test_with_missing_private_key() {
+        this.testSuite.include()
+
+        val jwk = Ed25519Generator.generate()
+        val missingKeyJwk = jwk.copy(d = null)
+
+        val signer = Ed25519Signer(missingKeyJwk)
+        val message = "Test message".toByteArray()
+        val exception = assertThrows<Web5Exception.Exception> {
+            signer.sign(message)
+        }
+
+        assertEquals("cryptography error private key material must be set", exception.msg)
+        assertEquals("Crypto", exception.variant)
+    }
+
+    companion object {
+        const val SIGNATURE_LENGTH = 64
+        const val SECRET_KEY_LENGTH = 32
     }
 }

--- a/bound/kt/src/test/kotlin/web5/sdk/crypto/verifiers/Ed25519VerifierTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/crypto/verifiers/Ed25519VerifierTest.kt
@@ -1,41 +1,127 @@
 package web5.sdk.crypto.verifiers
 
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.fail
+import web5.sdk.UnitTestSuite
+import web5.sdk.crypto.Ed25519Generator
 import web5.sdk.crypto.keys.Jwk
 import web5.sdk.crypto.signers.Ed25519Signer
-import web5.sdk.rust.ed25519GeneratorGenerate as rustCoreEd25519GeneratorGenerate
+import web5.sdk.rust.Web5Exception
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Ed25519VerifierTest {
 
-    @Test
-    fun `test verifier with valid signature`() {
-        val privateJwk = rustCoreEd25519GeneratorGenerate()
-        val ed25519Signer = Ed25519Signer(Jwk.fromRustCoreJwkData(privateJwk))
+    private val testSuite = UnitTestSuite("ed25519_verify")
 
-        val message = "abc".toByteArray()
-        val signature = ed25519Signer.sign(message)
+    @AfterAll
+    fun verifyAllTestsIncluded() {
+        if (testSuite.tests.isNotEmpty()) {
+            println("The following tests were not included or executed:")
+            testSuite.tests.forEach { println(it) }
+            fail("Not all tests were executed! ${this.testSuite.tests}")
+        }
+    }
 
-        val ed25519Verifier = Ed25519Verifier(Jwk.fromRustCoreJwkData(privateJwk))
-        val isValid = ed25519Verifier.verify(message, signature)
-
-        assertTrue(isValid, "Signature should be valid")
+    private fun generateKeys(): Pair<Jwk, Jwk> {
+        val privateJwk = Ed25519Generator.generate()
+        val publicJwk = privateJwk.copy(d = null)
+        return Pair(publicJwk, privateJwk)
     }
 
     @Test
-    fun `test verifier with invalid signature`() {
-        val privateJwk = rustCoreEd25519GeneratorGenerate()
-        val ed25519Signer = Ed25519Signer(Jwk.fromRustCoreJwkData(privateJwk))
+    fun test_with_valid_signature() {
+        this.testSuite.include()
 
-        val message = "abc".toByteArray()
-        val signature = ed25519Signer.sign(message)
+        val (publicJwk, privateJwk) = generateKeys()
+        val signer = Ed25519Signer(privateJwk)
+        val verifier = Ed25519Verifier(publicJwk)
 
-        val modifiedMessage = "abcd".toByteArray()
+        val message = "Test message".toByteArray()
+        val signature = signer.sign(message)
 
-        val ed25519Verifier = Ed25519Verifier(Jwk.fromRustCoreJwkData(privateJwk))
-        val isValid = ed25519Verifier.verify(modifiedMessage, signature)
+        val verifyResult = runCatching { verifier.verify(message, signature) }
 
-        assertFalse(isValid, "Signature should be invalid")
+        assertTrue(verifyResult.isSuccess, "Verification should succeed with a valid signature")
+    }
+
+    @Test
+    fun test_with_private_key() {
+        this.testSuite.include()
+
+        val (_, privateJwk) = generateKeys()
+        val verifier = Ed25519Verifier(privateJwk) // this is not allowed
+
+        val message = "Test message".toByteArray()
+        val invalidSignature = ByteArray(SIGNATURE_LENGTH - 1) // invalid length
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            verifier.verify(message, invalidSignature)
+        }
+
+        assertEquals("cryptography error provided verification key cannot contain private key material", exception.msg)
+        assertEquals("Crypto", exception.variant)
+    }
+
+    @Test
+    fun test_with_invalid_signature() {
+        this.testSuite.include()
+
+        val (publicJwk, _) = generateKeys()
+        val verifier = Ed25519Verifier(publicJwk)
+
+        val message = "Test message".toByteArray()
+        val invalidSignature = ByteArray(SIGNATURE_LENGTH) // an obviously invalid signature
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            verifier.verify(message, invalidSignature)
+        }
+
+        assertEquals("cryptography error cryptographic verification failure", exception.msg)
+        assertEquals("Crypto", exception.variant)
+    }
+
+    @Test
+    fun test_with_invalid_public_key() {
+        this.testSuite.include()
+
+        val (publicJwk, privateJwk) = generateKeys()
+        val invalidPublicJwk = publicJwk.copy(x = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(ByteArray(PUBLIC_KEY_LENGTH - 1)))
+
+        val signer = Ed25519Signer(privateJwk)
+        val verifier = Ed25519Verifier(invalidPublicJwk)
+
+        val message = "Test message".toByteArray()
+        val signature = signer.sign(message)
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            verifier.verify(message, signature)
+        }
+
+        assertEquals("cryptography error invalid public key length ${PUBLIC_KEY_LENGTH - 1} must be $PUBLIC_KEY_LENGTH", exception.msg)
+        assertEquals("Crypto", exception.variant)
+    }
+
+    @Test
+    fun test_with_invalid_signature_length() {
+        this.testSuite.include()
+
+        val (publicJwk, _) = generateKeys()
+        val verifier = Ed25519Verifier(publicJwk)
+
+        val message = "Test message".toByteArray()
+        val invalidSignature = ByteArray(SIGNATURE_LENGTH - 1) // invalid length
+
+        val exception = assertThrows<Web5Exception.Exception> {
+            verifier.verify(message, invalidSignature)
+        }
+
+        assertEquals("cryptography error invalid signature length ${SIGNATURE_LENGTH - 1} must be $SIGNATURE_LENGTH", exception.msg)
+        assertEquals("Crypto", exception.variant)
+    }
+
+    companion object {
+        const val SIGNATURE_LENGTH = 64
+        const val PUBLIC_KEY_LENGTH = 32
     }
 }

--- a/crates/web5/src/credentials/verifiable_credential_1_1.rs
+++ b/crates/web5/src/credentials/verifiable_credential_1_1.rs
@@ -6,7 +6,7 @@ use crate::rfc3339::{
     serialize_system_time,
 };
 use crate::{
-    crypto::dsa::{ed25519::Ed25519Verifier, DsaError, Signer, Verifier},
+    crypto::dsa::{ed25519::Ed25519Verifier, Signer, Verifier},
     dids::{
         bearer_did::BearerDid,
         did::Did,
@@ -515,18 +515,9 @@ impl JosekitJwsVerifier for JoseVerifier {
     }
 
     fn verify(&self, message: &[u8], signature: &[u8]) -> core::result::Result<(), JosekitError> {
-        let result = self
-            .verifier
+        self.verifier
             .verify(message, signature)
-            .map_err(|e| JosekitError::InvalidSignature(e.into()))?;
-
-        match result {
-            true => Ok(()),
-            false => Err(JosekitError::InvalidSignature(
-                // 🚧 improve error message semantics
-                DsaError::VerificationFailure("ed25519 verification failed".to_string()).into(),
-            )),
-        }
+            .map_err(|e| JosekitError::InvalidSignature(e.into()))
     }
 
     fn box_clone(&self) -> Box<dyn JosekitJwsVerifier> {

--- a/crates/web5/src/crypto/dsa/ed25519.rs
+++ b/crates/web5/src/crypto/dsa/ed25519.rs
@@ -1,5 +1,8 @@
-use super::{DsaError, Result, Signer, Verifier};
-use crate::crypto::jwk::Jwk;
+use super::{Signer, Verifier};
+use crate::{
+    crypto::jwk::Jwk,
+    errors::{Result, Web5Error},
+};
 use base64::{engine::general_purpose, Engine as _};
 use ed25519_dalek::{
     Signature, Signer as DalekSigner, SigningKey, Verifier as DalekVerifier, VerifyingKey,
@@ -30,7 +33,7 @@ impl Ed25519Generator {
 
 pub(crate) fn public_jwk_from_bytes(public_key: &[u8]) -> Result<Jwk> {
     if public_key.len() != PUBLIC_KEY_LENGTH {
-        return Err(DsaError::PublicKeyFailure(format!(
+        return Err(Web5Error::Parameter(format!(
             "Public key has incorrect length {}",
             PUBLIC_KEY_LENGTH
         )));
@@ -61,7 +64,10 @@ pub(crate) fn public_jwk_extract_bytes(jwk: &Jwk) -> Result<Vec<u8>> {
     let decoded_x = general_purpose::URL_SAFE_NO_PAD.decode(&jwk.x)?;
 
     if decoded_x.len() != PUBLIC_KEY_LENGTH {
-        return Err(DsaError::InvalidKeyLength(PUBLIC_KEY_LENGTH.to_string()));
+        return Err(Web5Error::Parameter(format!(
+            "public key invalid length {}",
+            PUBLIC_KEY_LENGTH
+        )));
     }
 
     Ok(decoded_x)
@@ -80,14 +86,16 @@ impl Ed25519Signer {
 
 impl Signer for Ed25519Signer {
     fn sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        let d = self
-            .private_jwk
-            .d
-            .as_ref()
-            .ok_or(DsaError::MissingPrivateKey)?;
+        let d = self.private_jwk.d.as_ref().ok_or(Web5Error::Crypto(
+            "private key material must be set".to_string(),
+        ))?;
         let decoded_d = general_purpose::URL_SAFE_NO_PAD.decode(d)?;
         if decoded_d.len() != SECRET_KEY_LENGTH {
-            return Err(DsaError::InvalidKeyLength(SECRET_KEY_LENGTH.to_string()));
+            return Err(Web5Error::Crypto(format!(
+                "invalid private key length {} must be {}",
+                decoded_d.len(),
+                SECRET_KEY_LENGTH
+            )));
         }
         let mut key_array = [0u8; 32];
         key_array.copy_from_slice(&decoded_d);
@@ -109,20 +117,28 @@ impl Ed25519Verifier {
 }
 
 impl Verifier for Ed25519Verifier {
-    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<bool> {
+    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<()> {
         let mut public_key_bytes = [0u8; PUBLIC_KEY_LENGTH];
         let decoded_x = general_purpose::URL_SAFE_NO_PAD.decode(&self.public_jwk.x)?;
 
         if decoded_x.len() != PUBLIC_KEY_LENGTH {
-            return Err(DsaError::InvalidKeyLength(PUBLIC_KEY_LENGTH.to_string()));
+            return Err(Web5Error::Crypto(format!(
+                "invalid public key length {} must be {}",
+                decoded_x.len(),
+                PUBLIC_KEY_LENGTH
+            )));
         }
 
         public_key_bytes.copy_from_slice(&decoded_x);
         let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
-            .map_err(|e| DsaError::PublicKeyFailure(e.to_string()))?;
+            .map_err(|e| Web5Error::Crypto(format!("unable to instantiate verifying key {}", e)))?;
 
         if signature.len() != SIGNATURE_LENGTH {
-            return Err(DsaError::InvalidSignatureLength(self.public_jwk.x.clone()));
+            return Err(Web5Error::Crypto(format!(
+                "invalid signature length {} must be {}",
+                signature.len(),
+                SIGNATURE_LENGTH
+            )));
         }
 
         let mut signature_bytes = [0u8; SIGNATURE_LENGTH];
@@ -130,8 +146,282 @@ impl Verifier for Ed25519Verifier {
         let verify_result = verifying_key.verify(payload, &Signature::from_bytes(&signature_bytes));
 
         match verify_result {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false),
+            Ok(_) => Ok(()),
+            Err(_) => Err(Web5Error::Crypto(
+                "cryptographic verification failure".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_helpers::UnitTestSuite, test_name};
+    use general_purpose::URL_SAFE_NO_PAD;
+    use std::sync::LazyLock;
+
+    mod generate {
+        use super::*;
+
+        static TEST_SUITE: LazyLock<UnitTestSuite> =
+            LazyLock::new(|| UnitTestSuite::new("ed25519_generate"));
+
+        #[test]
+        fn z_assert_all_suite_cases_covered() {
+            // fn name prefixed with `z_*` b/c rust test harness executes in alphabetical order,
+            // unless intentionally executed with "shuffle" https://doc.rust-lang.org/rustc/tests/index.html#--shuffle
+            // this may not work if shuffled or if test list grows to the extent of 100ms being insufficient wait time
+
+            // wait 100ms to be last-in-queue of mutex lock
+            std::thread::sleep(std::time::Duration::from_millis(100));
+
+            TEST_SUITE.assert_coverage()
+        }
+
+        #[test]
+        fn test_must_set_alg() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            assert_eq!(jwk.alg, Some("Ed25519".to_string()));
+        }
+
+        #[test]
+        fn test_must_set_kty() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            assert_eq!(jwk.kty, "OKP".to_string());
+        }
+
+        #[test]
+        fn test_must_set_crv() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            assert_eq!(jwk.crv, "Ed25519");
+        }
+
+        #[test]
+        fn test_must_set_public_key_with_correct_length() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            let public_key_bytes = URL_SAFE_NO_PAD
+                .decode(&jwk.x)
+                .expect("Failed to decode public key");
+            assert_eq!(public_key_bytes.len(), PUBLIC_KEY_LENGTH);
+        }
+
+        #[test]
+        fn test_must_set_private_key_with_correct_length() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            let private_key_bytes = jwk.d.expect("Private key is missing");
+            let decoded_private_key_bytes = URL_SAFE_NO_PAD
+                .decode(private_key_bytes)
+                .expect("Failed to decode private key");
+            assert_eq!(decoded_private_key_bytes.len(), SECRET_KEY_LENGTH);
+        }
+    }
+
+    mod sign {
+        use super::*;
+
+        static TEST_SUITE: LazyLock<UnitTestSuite> =
+            LazyLock::new(|| UnitTestSuite::new("ed25519_sign"));
+
+        #[test]
+        fn z_assert_all_suite_cases_covered() {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            TEST_SUITE.assert_coverage();
+        }
+
+        #[test]
+        fn test_with_valid_key() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            let signer = Ed25519Signer::new(jwk);
+
+            let message = b"Test message";
+            let signature_result = signer.sign(message);
+
+            assert!(
+                signature_result.is_ok(),
+                "Signing should succeed with a valid key"
+            );
+
+            let signature = signature_result.unwrap();
+            assert_eq!(
+                signature.len(),
+                SIGNATURE_LENGTH,
+                "Signature length should match the expected Ed25519 signature length"
+            );
+        }
+
+        #[test]
+        fn test_with_invalid_private_key() {
+            TEST_SUITE.include(test_name!());
+
+            let mut jwk = Ed25519Generator::generate();
+
+            // Set an invalid private key (wrong length)
+            jwk.d = Some(URL_SAFE_NO_PAD.encode(&[0u8; SECRET_KEY_LENGTH - 1]));
+
+            let signer = Ed25519Signer::new(jwk);
+            let message = b"Test message";
+            let signature_result = signer.sign(message);
+
+            assert!(
+                signature_result.is_err(),
+                "Signing should fail with an invalid private key"
+            );
+            assert_eq!(
+                signature_result.unwrap_err(),
+                Web5Error::Crypto(format!(
+                    "invalid private key length {} must be {}",
+                    SECRET_KEY_LENGTH - 1,
+                    SECRET_KEY_LENGTH
+                ))
+            );
+        }
+
+        #[test]
+        fn test_with_missing_private_key() {
+            TEST_SUITE.include(test_name!());
+
+            let mut jwk = Ed25519Generator::generate();
+
+            // Remove the private key
+            jwk.d = None;
+
+            let signer = Ed25519Signer::new(jwk);
+            let message = b"Test message";
+            let signature_result = signer.sign(message);
+
+            assert!(
+                signature_result.is_err(),
+                "Signing should fail if the private key is missing"
+            );
+            assert_eq!(
+                signature_result.unwrap_err(),
+                Web5Error::Crypto("private key material must be set".to_string())
+            );
+        }
+    }
+
+    mod verify {
+        use super::*;
+
+        static TEST_SUITE: LazyLock<UnitTestSuite> =
+            LazyLock::new(|| UnitTestSuite::new("ed25519_verify"));
+
+        #[test]
+        fn z_assert_all_suite_cases_covered() {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            TEST_SUITE.assert_coverage();
+        }
+
+        #[test]
+        fn test_with_valid_signature() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            let signer = Ed25519Signer::new(jwk.clone());
+            let verifier = Ed25519Verifier::new(jwk);
+
+            let message = b"Test message";
+            let signature = signer.sign(message).expect("Signing failed");
+
+            let verify_result = verifier.verify(message, &signature);
+
+            assert!(
+                verify_result.is_ok(),
+                "Verification should succeed with a valid signature"
+            );
+        }
+
+        #[test]
+        fn test_with_invalid_signature() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            let verifier = Ed25519Verifier::new(jwk);
+
+            let message = b"Test message";
+            let invalid_signature = vec![0u8; SIGNATURE_LENGTH]; // an obviously invalid signature
+
+            let verify_result = verifier.verify(message, &invalid_signature);
+
+            assert!(
+                verify_result.is_err(),
+                "Verification should fail with an invalid signature"
+            );
+            assert_eq!(
+                verify_result.unwrap_err(),
+                Web5Error::Crypto("cryptographic verification failure".to_string())
+            );
+        }
+
+        #[test]
+        fn test_with_invalid_public_key() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            let mut invalid_jwk = jwk.clone();
+
+            // Set an invalid public key (wrong length)
+            invalid_jwk.x = URL_SAFE_NO_PAD.encode(&[0u8; PUBLIC_KEY_LENGTH - 1]);
+
+            let verifier = Ed25519Verifier::new(invalid_jwk);
+            let message = b"Test message";
+            let signature = Ed25519Signer::new(jwk)
+                .sign(message)
+                .expect("Signing failed");
+
+            let verify_result = verifier.verify(message, &signature);
+
+            assert!(
+                verify_result.is_err(),
+                "Verification should fail with an invalid public key"
+            );
+            assert_eq!(
+                verify_result.unwrap_err(),
+                Web5Error::Crypto(format!(
+                    "invalid public key length {} must be {}",
+                    PUBLIC_KEY_LENGTH - 1,
+                    PUBLIC_KEY_LENGTH
+                ))
+            );
+        }
+
+        #[test]
+        fn test_with_invalid_signature_length() {
+            TEST_SUITE.include(test_name!());
+
+            let jwk = Ed25519Generator::generate();
+            let verifier = Ed25519Verifier::new(jwk);
+
+            let message = b"Test message";
+            let invalid_signature = vec![0u8; SIGNATURE_LENGTH - 1]; // invalid length
+
+            let verify_result = verifier.verify(message, &invalid_signature);
+
+            assert!(
+                verify_result.is_err(),
+                "Verification should fail with a signature of incorrect length"
+            );
+            assert_eq!(
+                verify_result.unwrap_err(),
+                Web5Error::Crypto(format!(
+                    "invalid signature length {} must be {}",
+                    SIGNATURE_LENGTH - 1,
+                    SIGNATURE_LENGTH
+                ))
+            );
         }
     }
 }

--- a/crates/web5/src/crypto/dsa/ed25519.rs
+++ b/crates/web5/src/crypto/dsa/ed25519.rs
@@ -118,6 +118,14 @@ impl Ed25519Verifier {
 
 impl Verifier for Ed25519Verifier {
     fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<()> {
+        if let Some(d) = &self.public_jwk.d {
+            if !d.is_empty() {
+                return Err(Web5Error::Crypto(
+                    "provided verification key cannot contain private key material".to_string(),
+                ));
+            }
+        }
+
         let mut public_key_bytes = [0u8; PUBLIC_KEY_LENGTH];
         let decoded_x = general_purpose::URL_SAFE_NO_PAD.decode(&self.public_jwk.x)?;
 

--- a/crates/web5/src/crypto/dsa/mod.rs
+++ b/crates/web5/src/crypto/dsa/mod.rs
@@ -1,39 +1,7 @@
+use crate::errors::{Result, Web5Error};
+
 pub mod ed25519;
 pub(crate) mod secp256k1;
-
-use base64::DecodeError;
-
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
-pub enum DsaError {
-    #[error("missing required private key")]
-    MissingPrivateKey,
-    #[error("base64 decode error {0}")]
-    DecodeError(String),
-    #[error("invalid key length {0}")]
-    InvalidKeyLength(String),
-    #[error("invalid signature length {0}")]
-    InvalidSignatureLength(String),
-    #[error("public key failure {0}")]
-    PublicKeyFailure(String),
-    #[error("private key failure {0}")]
-    PrivateKeyFailure(String),
-    #[error("verification failure {0}")]
-    VerificationFailure(String),
-    #[error("sign failure {0}")]
-    SignFailure(String),
-    #[error("unsupported curve")]
-    UnsupportedDsa,
-    #[error("unknown error")]
-    Unknown,
-}
-
-impl From<DecodeError> for DsaError {
-    fn from(error: DecodeError) -> Self {
-        Self::DecodeError(error.to_string())
-    }
-}
-
-pub type Result<T> = std::result::Result<T, DsaError>;
 
 pub enum Dsa {
     Ed25519,
@@ -42,14 +10,14 @@ pub enum Dsa {
 }
 
 impl std::str::FromStr for Dsa {
-    type Err = DsaError;
+    type Err = Web5Error;
 
-    fn from_str(input: &str) -> std::result::Result<Self, DsaError> {
+    fn from_str(input: &str) -> std::result::Result<Self, Web5Error> {
         match input.to_ascii_lowercase().as_str() {
             "ed25519" => Ok(Dsa::Ed25519),
             #[cfg(test)]
             "secp256k1" => Ok(Dsa::Secp256k1),
-            _ => Err(DsaError::UnsupportedDsa),
+            _ => Err(Web5Error::Parameter(format!("unsupported dsa {}", input))),
         }
     }
 }
@@ -59,5 +27,5 @@ pub trait Signer: Send + Sync {
 }
 
 pub trait Verifier: Send + Sync {
-    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<bool>;
+    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<()>;
 }

--- a/crates/web5/src/crypto/dsa/mod.rs
+++ b/crates/web5/src/crypto/dsa/mod.rs
@@ -1,7 +1,7 @@
 use crate::errors::{Result, Web5Error};
 
 pub mod ed25519;
-pub(crate) mod secp256k1;
+pub mod secp256k1;
 
 pub enum Dsa {
     Ed25519,

--- a/crates/web5/src/crypto/dsa/secp256k1.rs
+++ b/crates/web5/src/crypto/dsa/secp256k1.rs
@@ -3,12 +3,9 @@ use crate::errors::Result;
 use crate::errors::Web5Error;
 use base64::{engine::general_purpose, Engine as _};
 
-#[cfg(test)]
 pub struct Secp256k1Generator;
 
-#[cfg(test)]
 impl Secp256k1Generator {
-    #[cfg(test)]
     pub fn generate() -> Jwk {
         let signing_key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let verifying_key = signing_key.verifying_key();

--- a/crates/web5/src/crypto/dsa/secp256k1.rs
+++ b/crates/web5/src/crypto/dsa/secp256k1.rs
@@ -25,6 +25,7 @@ impl Secp256k1Generator {
     }
 }
 
+#[cfg(test)]
 pub fn to_public_jwk(jwk: &Jwk) -> Jwk {
     Jwk {
         alg: jwk.alg.clone(),

--- a/crates/web5/src/crypto/dsa/secp256k1.rs
+++ b/crates/web5/src/crypto/dsa/secp256k1.rs
@@ -1,5 +1,10 @@
-use super::{DsaError, Result};
+#[cfg(test)]
 use crate::crypto::jwk::Jwk;
+#[cfg(test)]
+use crate::errors::Result;
+#[cfg(test)]
+use crate::errors::Web5Error;
+#[cfg(test)]
 use base64::{engine::general_purpose, Engine as _};
 
 #[cfg(test)]
@@ -43,7 +48,7 @@ pub fn public_jwk_extract_bytes(jwk: &Jwk) -> Result<Vec<u8>> {
     let decoded_y = general_purpose::URL_SAFE_NO_PAD.decode(
         jwk.y
             .as_ref()
-            .ok_or(DsaError::PublicKeyFailure("missing y".to_string()))?,
+            .ok_or(Web5Error::Parameter("missing y".to_string()))?,
     )?;
 
     let mut pk_bytes = Vec::with_capacity(1 + decoded_x.len() + decoded_y.len());

--- a/crates/web5/src/crypto/dsa/secp256k1.rs
+++ b/crates/web5/src/crypto/dsa/secp256k1.rs
@@ -3,9 +3,12 @@ use crate::errors::Result;
 use crate::errors::Web5Error;
 use base64::{engine::general_purpose, Engine as _};
 
+#[cfg(test)]
 pub struct Secp256k1Generator;
 
+#[cfg(test)]
 impl Secp256k1Generator {
+    #[cfg(test)]
     pub fn generate() -> Jwk {
         let signing_key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let verifying_key = signing_key.verifying_key();

--- a/crates/web5/src/crypto/dsa/secp256k1.rs
+++ b/crates/web5/src/crypto/dsa/secp256k1.rs
@@ -1,16 +1,10 @@
-#[cfg(test)]
 use crate::crypto::jwk::Jwk;
-#[cfg(test)]
 use crate::errors::Result;
-#[cfg(test)]
 use crate::errors::Web5Error;
-#[cfg(test)]
 use base64::{engine::general_purpose, Engine as _};
 
-#[cfg(test)]
 pub struct Secp256k1Generator;
 
-#[cfg(test)]
 impl Secp256k1Generator {
     pub fn generate() -> Jwk {
         let signing_key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
@@ -31,7 +25,6 @@ impl Secp256k1Generator {
     }
 }
 
-#[cfg(test)]
 pub fn to_public_jwk(jwk: &Jwk) -> Jwk {
     Jwk {
         alg: jwk.alg.clone(),

--- a/crates/web5/src/dids/methods/did_dht/bep44.rs
+++ b/crates/web5/src/dids/methods/did_dht/bep44.rs
@@ -19,7 +19,7 @@ const MAX_MESSAGE_LEN: usize = MAX_V_LEN + MIN_MESSAGE_LEN;
 
 /// Errors that can occur when working with Bep44 messages for did:dht.
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum Bep44EncodingError {
+pub enum Bep44EncodingError {
     #[error(transparent)]
     SystemTime(#[from] SystemTimeError),
     #[error(transparent)]
@@ -33,7 +33,7 @@ pub(crate) enum Bep44EncodingError {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct Bep44Message {
+pub struct Bep44Message {
     /// The sequence number of the message, used to ensure the latest version of
     /// the data is retrieved and updated. It's a monotonically increasing number.
     pub seq: u64,

--- a/crates/web5/src/dids/methods/did_dht/bep44.rs
+++ b/crates/web5/src/dids/methods/did_dht/bep44.rs
@@ -158,7 +158,9 @@ mod tests {
 
         let bep44_message = result_bep44_message.unwrap();
 
-        let verifier = Ed25519Verifier::new(private_jwk);
+        let mut public_jwk = private_jwk.clone();
+        public_jwk.d = None;
+        let verifier = Ed25519Verifier::new(public_jwk);
         let verify_result = bep44_message.verify(&verifier);
         assert!(verify_result.is_ok());
     }

--- a/crates/web5/src/dids/methods/did_dht/bep44.rs
+++ b/crates/web5/src/dids/methods/did_dht/bep44.rs
@@ -3,7 +3,10 @@ use std::{
     time::{SystemTime, SystemTimeError, UNIX_EPOCH},
 };
 
-use crate::crypto::dsa::{ed25519::Ed25519Verifier, DsaError, Verifier};
+use crate::{
+    crypto::dsa::{ed25519::Ed25519Verifier, Verifier},
+    errors::Web5Error,
+};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 /// Minimum size of a bep44 encoded message
@@ -16,21 +19,21 @@ const MAX_MESSAGE_LEN: usize = MAX_V_LEN + MIN_MESSAGE_LEN;
 
 /// Errors that can occur when working with Bep44 messages for did:dht.
 #[derive(thiserror::Error, Debug)]
-pub enum Bep44EncodingError {
+pub(crate) enum Bep44EncodingError {
     #[error(transparent)]
-    SystemTimeError(#[from] SystemTimeError),
+    SystemTime(#[from] SystemTimeError),
     #[error(transparent)]
-    DsaError(#[from] DsaError),
+    Web5Error(#[from] Web5Error),
     #[error("Failure creating DID: {0}")]
-    BigEndianError(String),
+    BigEndian(String),
     #[error(
         "Message must have size between {MIN_MESSAGE_LEN} and {MAX_MESSAGE_LEN} but got size {0}"
     )]
-    SizeError(usize),
+    Size(usize),
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Bep44Message {
+pub(crate) struct Bep44Message {
     /// The sequence number of the message, used to ensure the latest version of
     /// the data is retrieved and updated. It's a monotonically increasing number.
     pub seq: u64,
@@ -50,17 +53,17 @@ fn signable(seq: u64, message: &[u8]) -> Vec<u8> {
 
 fn encode_seq(seq: u64) -> Result<Vec<u8>, Bep44EncodingError> {
     let mut seq_bytes = vec![];
-    seq_bytes.write_u64::<BigEndian>(seq).map_err(|_| {
-        Bep44EncodingError::BigEndianError("Failed to write big endian seq".to_string())
-    })?;
+    seq_bytes
+        .write_u64::<BigEndian>(seq)
+        .map_err(|_| Bep44EncodingError::BigEndian("Failed to write big endian seq".to_string()))?;
     Ok(seq_bytes)
 }
 
 fn decode_seq(seq_bytes: &[u8]) -> Result<u64, Bep44EncodingError> {
     let mut rdr = Cursor::new(seq_bytes);
-    let seq = rdr.read_u64::<BigEndian>().map_err(|_| {
-        Bep44EncodingError::BigEndianError("Failed to read big endian seq".to_string())
-    })?;
+    let seq = rdr
+        .read_u64::<BigEndian>()
+        .map_err(|_| Bep44EncodingError::BigEndian("Failed to read big endian seq".to_string()))?;
     Ok(seq)
 }
 
@@ -76,11 +79,11 @@ fn decode_seq(seq_bytes: &[u8]) -> Result<u64, Bep44EncodingError> {
 impl Bep44Message {
     pub fn new<F>(message: &[u8], sign: F) -> Result<Self, Bep44EncodingError>
     where
-        F: Fn(Vec<u8>) -> Result<Vec<u8>, DsaError>,
+        F: Fn(Vec<u8>) -> Result<Vec<u8>, Web5Error>,
     {
         let message_len = message.len();
         if message_len > MAX_V_LEN {
-            return Err(Bep44EncodingError::SizeError(message_len));
+            return Err(Bep44EncodingError::Size(message_len));
         }
 
         let seq = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
@@ -109,7 +112,7 @@ impl Bep44Message {
     pub fn decode(message_bytes: &[u8]) -> Result<Self, Bep44EncodingError> {
         let message_len = message_bytes.len();
         if !(MIN_MESSAGE_LEN..=MAX_MESSAGE_LEN).contains(&message_len) {
-            return Err(Bep44EncodingError::SizeError(message_len));
+            return Err(Bep44EncodingError::Size(message_len));
         }
 
         let sig = &message_bytes[0..64];
@@ -125,13 +128,7 @@ impl Bep44Message {
 
     pub fn verify(&self, verifier: &Ed25519Verifier) -> Result<(), Bep44EncodingError> {
         let signable = signable(self.seq, &self.v);
-        let is_verified = verifier.verify(&signable, &self.sig)?;
-
-        if !is_verified {
-            return Err(Bep44EncodingError::DsaError(DsaError::VerificationFailure(
-                "bep44 verification failure".to_string(),
-            )));
-        }
+        verifier.verify(&signable, &self.sig)?;
 
         Ok(())
     }
@@ -154,7 +151,7 @@ mod tests {
         let signer = Ed25519Signer::new(private_jwk.clone());
 
         let result_bep44_message =
-            Bep44Message::new(message, |payload| -> Result<Vec<u8>, DsaError> {
+            Bep44Message::new(message, |payload| -> Result<Vec<u8>, Web5Error> {
                 signer.sign(&payload)
             });
         assert!(result_bep44_message.is_ok());
@@ -169,11 +166,11 @@ mod tests {
     #[test]
     fn test_new_message_too_big() {
         let too_big = vec![0; 10_000];
-        let error = Bep44Message::new(&too_big, |_| -> Result<Vec<u8>, DsaError> { Ok(vec![]) })
+        let error = Bep44Message::new(&too_big, |_| -> Result<Vec<u8>, Web5Error> { Ok(vec![]) })
             .expect_err("Should have returned error for malformed signature");
 
         match error {
-            Bep44EncodingError::SizeError(size) => assert_eq!(size, 10_000),
+            Bep44EncodingError::Size(size) => assert_eq!(size, 10_000),
             _ => panic!(),
         }
     }
@@ -182,13 +179,13 @@ mod tests {
     fn test_new_sign_fails() {
         let message = "Hello World".as_bytes();
 
-        let error = Bep44Message::new(message, |_| -> Result<Vec<u8>, DsaError> {
-            Err(DsaError::UnsupportedDsa)
+        let error = Bep44Message::new(message, |_| -> Result<Vec<u8>, Web5Error> {
+            Err(Web5Error::Parameter("some example error".to_string()))
         })
         .expect_err("Should have returned error for malformed signature");
 
         match error {
-            Bep44EncodingError::DsaError(_) => {}
+            Bep44EncodingError::Web5Error(_) => {}
             _ => panic!(),
         }
     }
@@ -201,7 +198,7 @@ mod tests {
         let signer = Ed25519Signer::new(private_jwk.clone());
 
         let mut bep44_message =
-            Bep44Message::new(message, |payload| -> Result<Vec<u8>, DsaError> {
+            Bep44Message::new(message, |payload| -> Result<Vec<u8>, Web5Error> {
                 signer.sign(&payload)
             })
             .unwrap();
@@ -220,7 +217,7 @@ mod tests {
         let private_jwk = Ed25519Generator::generate();
         let signer = Ed25519Signer::new(private_jwk);
 
-        let bep44_message = Bep44Message::new(message, |payload| -> Result<Vec<u8>, DsaError> {
+        let bep44_message = Bep44Message::new(message, |payload| -> Result<Vec<u8>, Web5Error> {
             signer.sign(&payload)
         })
         .unwrap();
@@ -239,7 +236,7 @@ mod tests {
         let error = Bep44Message::decode(&too_short)
             .expect_err("Should error because bep44 message is too short");
         match error {
-            Bep44EncodingError::SizeError(_) => {}
+            Bep44EncodingError::Size(_) => {}
             _ => panic!(),
         }
 
@@ -247,7 +244,7 @@ mod tests {
         let error = Bep44Message::decode(&too_long)
             .expect_err("Should error because bep44 message is too long");
         match error {
-            Bep44EncodingError::SizeError(_) => {}
+            Bep44EncodingError::Size(_) => {}
             _ => panic!(),
         }
     }

--- a/crates/web5/src/dids/methods/did_dht/document_packet/mod.rs
+++ b/crates/web5/src/dids/methods/did_dht/document_packet/mod.rs
@@ -1,4 +1,3 @@
-use crate::crypto::dsa::DsaError;
 use crate::dids::data_model::document::Document;
 use crate::dids::data_model::{service::Service, verification_method::VerificationMethod};
 use crate::errors::Web5Error;
@@ -46,8 +45,6 @@ fn reconstitute_verification_relationship(
 /// Errors that can occur when converting between did:dht documents and DNS packets.
 #[derive(thiserror::Error, Debug)]
 pub enum DocumentPacketError {
-    #[error(transparent)]
-    DsaError(#[from] DsaError),
     #[error("DID Document is malformed for did:dht: {0}")]
     DocumentError(String),
     #[error(transparent)]

--- a/crates/web5/src/dids/methods/did_dht/mod.rs
+++ b/crates/web5/src/dids/methods/did_dht/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use std::sync::Arc;
 
-pub(crate) mod bep44;
+mod bep44;
 pub mod document_packet;
 
 const JSON_WEB_KEY: &str = "JsonWebKey";

--- a/crates/web5/src/dids/methods/did_dht/mod.rs
+++ b/crates/web5/src/dids/methods/did_dht/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use std::sync::Arc;
 
-pub mod bep44;
+pub(crate) mod bep44;
 pub mod document_packet;
 
 const JSON_WEB_KEY: &str = "JsonWebKey";

--- a/crates/web5/src/dids/methods/mod.rs
+++ b/crates/web5/src/dids/methods/mod.rs
@@ -1,4 +1,4 @@
-use crate::{crypto::dsa::DsaError, errors::Web5Error};
+use crate::errors::Web5Error;
 
 use super::resolution::resolution_metadata::ResolutionMetadataError;
 use base64::DecodeError;
@@ -23,8 +23,6 @@ pub enum MethodError {
     DecodeError(#[from] DecodeError),
     #[error(transparent)]
     ResolutionError(#[from] ResolutionMetadataError),
-    #[error(transparent)]
-    DsaError(#[from] DsaError),
 }
 
 impl From<SerdeJsonError> for MethodError {

--- a/crates/web5/src/errors.rs
+++ b/crates/web5/src/errors.rs
@@ -1,7 +1,10 @@
+use base64::DecodeError;
 use serde_json::Error as SerdeJsonError;
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum Web5Error {
+    #[error("unknown error {0}")]
+    Unknown(String),
     #[error("json error {0}")]
     Json(String),
     #[error("parameter error {0}")]
@@ -10,6 +13,16 @@ pub enum Web5Error {
     DataMember(String),
     #[error("not found error {0}")]
     NotFound(String),
+    #[error("cryptography error {0}")]
+    Crypto(String),
+    #[error("encoding error {0}")]
+    Encoding(String),
+}
+
+impl From<DecodeError> for Web5Error {
+    fn from(err: DecodeError) -> Self {
+        Web5Error::Encoding(err.to_string())
+    }
 }
 
 impl From<SerdeJsonError> for Web5Error {
@@ -18,4 +31,4 @@ impl From<SerdeJsonError> for Web5Error {
     }
 }
 
-pub(crate) type Result<T> = std::result::Result<T, Web5Error>;
+pub type Result<T> = std::result::Result<T, Web5Error>;

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -266,7 +266,7 @@ INTERFACE Signer
 /// Set of functionality required to implement to be a compatible DSA verifier.
 INTERFACE Verifier
   /// Execute the verification of the signature against the payload by using the encapsulated public key material.
-  METHOD verify(payload: []byte, signature: []byte): bool
+  METHOD verify(payload: []byte, signature: []byte)
 ```
 
 ### `Ed25519Generator`

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -300,7 +300,6 @@ CLASS Ed25519Verifier IMPLEMENTS Verifier
   METHOD verify(payload: []byte): bool
 ```
 
-
 ### `Secp256k1Generator`
 
 ```pseudocode!

--- a/tests/unit_test_cases/ed25519_generate.json
+++ b/tests/unit_test_cases/ed25519_generate.json
@@ -1,0 +1,7 @@
+[
+  "test_must_set_alg",
+  "test_must_set_kty",
+  "test_must_set_crv",
+  "test_must_set_public_key_with_correct_length",
+  "test_must_set_private_key_with_correct_length"
+]

--- a/tests/unit_test_cases/ed25519_sign.json
+++ b/tests/unit_test_cases/ed25519_sign.json
@@ -1,0 +1,5 @@
+[
+  "test_with_valid_key",
+  "test_with_invalid_private_key",
+  "test_with_missing_private_key"
+]

--- a/tests/unit_test_cases/ed25519_verify.json
+++ b/tests/unit_test_cases/ed25519_verify.json
@@ -1,5 +1,6 @@
 [
   "test_with_valid_signature",
+  "test_with_private_key",
   "test_with_invalid_signature",
   "test_with_invalid_public_key",
   "test_with_invalid_signature_length"

--- a/tests/unit_test_cases/ed25519_verify.json
+++ b/tests/unit_test_cases/ed25519_verify.json
@@ -1,0 +1,6 @@
+[
+  "test_with_valid_signature",
+  "test_with_invalid_signature",
+  "test_with_invalid_public_key",
+  "test_with_invalid_signature_length"
+]


### PR DESCRIPTION
Part of the iterative process of bringing the entirety of the code base up to speed, this PR focuses on the DSA components (signer, verifier, & ed25519).

- Introduce `Web5Error::Crypto` variant (& also `::Unknown` and `::Encoding` variants)
- Change `Verifier::verify()` function signature to utilize error for failure case (as opposed to boolean)
- Add comprehensive unit test coverage for Ed25519
- Write the Kotlin code for these matters, plus unit test coverage