### PR TITLE
Add status list cred apid

### DIFF
--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -105,7 +105,7 @@ CLASS VerifiableCredential
 
 ##### `CredentialStatus`
 
-```psuedocode!
+```pseudocode!
 CLASS CredentialStatus
   PUBLIC DATA id: string
   PUBLIC DATA type: []string

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -87,7 +87,6 @@ CLASS VerifiableCredential
   PUBLIC DATA expiration_date: datetime?
   PUBLIC DATA credentialSubject: CredentialSubject
 
-
   CONSTRUCTOR create(issuer: Issuer, credential_subject: CredentialSubject, options: CreateOptions)
 
   CONSTRUCTOR(vcjwt: string)

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -87,6 +87,7 @@ CLASS VerifiableCredential
   PUBLIC DATA expiration_date: datetime?
   PUBLIC DATA credentialSubject: CredentialSubject
 
+
   CONSTRUCTOR create(issuer: Issuer, credential_subject: CredentialSubject, options: CreateOptions)
 
   CONSTRUCTOR(vcjwt: string)
@@ -103,6 +104,15 @@ CLASS VerifiableCredential
 
 `Object` or `string`, and if `Object` then at least non-empty `id: string` and `name: string` data members.
 
+##### `CredentialStatus`
+
+```psuedocode!
+CLASS CredentialStatus
+  PUBLIC DATA statusPurpose: string
+  PUBLIC DATA statusListIndex: string
+  PUBLIC DATA statusListCredential: string
+```
+
 ##### `CreateOptions`
 
 ```psuedocode!
@@ -112,6 +122,21 @@ CLASS CreateOptions
   PUBLIC DATA type: []string?
   PUBLIC DATA issuance_date: datetime?
   PUBLIC DATA expiration_date: datetime?
+  PUBLIC DATA credentialStatus: CredentialStatus?
+```
+
+## StatusListCredential
+
+#### `StatusListCredential`
+
+```pseudocode!
+CLASS StatusListCredential IMPLEMENTS VerifiableCredential
+PUBLIC DATA status_purpose: string
+PUBLIC DATA credentials_to_disable: []VerifiableCredential
+
+CONSTRUCTOR create(issuer: Issuer, status_purpose: string, credentials_to_disable: []VerifiableCredential, options: CreateOptions?)
+
+METHOD update_credentials_to_disable(credentials_to_disable: []VerifiableCredential): StatusListCredential
 ```
 
 ## Presentation Exchange (PEX)

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -138,7 +138,7 @@ PUBLIC DATA credentials_to_disable: []VerifiableCredential
 CONSTRUCTOR create(issuer: Issuer, status_purpose: string, credentials_to_disable: []VerifiableCredential, options: CreateOptions?)
 
 METHOD update_credentials_to_disable(credentials_to_disable: []VerifiableCredential): StatusListCredential
-METHOD validate_credential_in_status_list(credential VerifiableCredential): bool
+METHOD is_disabled(credential VerifiableCredential): bool
 ```
 
 ## Presentation Exchange (PEX)

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -108,9 +108,11 @@ CLASS VerifiableCredential
 
 ```psuedocode!
 CLASS CredentialStatus
-  PUBLIC DATA statusPurpose: string
-  PUBLIC DATA statusListIndex: string
-  PUBLIC DATA statusListCredential: string
+  PUBLIC DATA id: string
+  PUBLIC DATA type: []string
+  PUBLIC DATA status_purpose: string
+  PUBLIC DATA status_list_index: string
+  PUBLIC DATA status_list_credential: string
 ```
 
 ##### `CreateOptions`
@@ -122,7 +124,7 @@ CLASS CreateOptions
   PUBLIC DATA type: []string?
   PUBLIC DATA issuance_date: datetime?
   PUBLIC DATA expiration_date: datetime?
-  PUBLIC DATA credentialStatus: CredentialStatus?
+  PUBLIC DATA credential_status: CredentialStatus?
 ```
 
 ## StatusListCredential
@@ -137,6 +139,7 @@ PUBLIC DATA credentials_to_disable: []VerifiableCredential
 CONSTRUCTOR create(issuer: Issuer, status_purpose: string, credentials_to_disable: []VerifiableCredential, options: CreateOptions?)
 
 METHOD update_credentials_to_disable(credentials_to_disable: []VerifiableCredential): StatusListCredential
+METHOD validate_credential_in_status_list(credential VerifiableCredential): bool
 ```
 
 ## Presentation Exchange (PEX)

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -132,13 +132,13 @@ CLASS CreateOptions
 
 ```pseudocode!
 CLASS StatusListCredential IMPLEMENTS VerifiableCredential
-PUBLIC DATA status_purpose: string
-PUBLIC DATA credentials_to_disable: []VerifiableCredential
-
-CONSTRUCTOR create(issuer: Issuer, status_purpose: string, credentials_to_disable: []VerifiableCredential, options: CreateOptions?)
-
-METHOD update_credentials_to_disable(credentials_to_disable: []VerifiableCredential): StatusListCredential
-METHOD is_disabled(credential VerifiableCredential): bool
+  PUBLIC DATA status_purpose: string
+  PUBLIC DATA credentials_to_disable: []VerifiableCredential
+  
+  CONSTRUCTOR create(issuer: Issuer, status_purpose: string, credentials_to_disable: []VerifiableCredential, options: CreateOptions?)
+  
+  METHOD update_credentials_to_disable(credentials_to_disable: []VerifiableCredential): StatusListCredential
+  METHOD is_disabled(credential VerifiableCredential): bool
 ```
 
 ## Presentation Exchange (PEX)


### PR DESCRIPTION
Here would be an example flow on how you would use status list credentials:

```rust
// Create the StatusListCredential
let status_list_credential = StatusListCredential::create(
    issuer(),
    "revocation".to_string(),
    vec![], // Initially, no credentials are disabled
    None // Initially no options
    )
).unwrap();

// Now that the status list is ready, create prereqs for the normal VC
let credential_status = Some(CredentialStatus {
    id: format!("{}/#94567", status_list_credential.id),
    r#type: "StatusList2021Entry".to_string(),
    status_purpose: "revocation".to_string(),
    status_list_index: "94567".to_string(),
    status_list_credential: status_list_credential.id.clone(),
});

let options = Some(VerifiableCredentialCreateOptions {
    credential_status,
    ..Default::default()
});

// Create a normal vc with credential_status option
let vc = VerifiableCredential::create(issuer(), credential_subject(), options).unwrap();

// VC is not revoked initially
let isRevoked = status_list_credential.is_disabled(&[vc])

status_list_credential.update_credentials_to_disable(&[vc])

// VC is revoked
let isRevoked = status_list_credential.is_disabled(&[vc])
```

^ This is an "offline mode" feature, something which makes more intuitive sense is an "online mode" where one could call vc.verify() and it would download the status list credential and then see if its revoked. This makes a lot of assumptions because the id of the status list cred does not have to be a pubically accessable url.


Also another feature which could be added is in the vanilla vc verify options, you could pass in a status_list_credential as an optinal field.

this brings up another point, when we `verify` a normal vc, and it has a credential `credential_status` field, it could be valid BUT revoked, so is that really "valid"

Note some of these things may read cleaner if you say is_revoked or update_credentials_to_revoke, however we can't use the word revoke, because this can be suspended or any other status we want to give it, so the all encompassing verb I used is disable

reference - https://www.w3.org/community/reports/credentials/CG-FINAL-vc-status-list-2021-20230102/