### PR TITLE
Decouple kt data structs from UniFFI codegen

### DIFF
--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -138,6 +138,10 @@ dictionary ServiceData {
 interface Document {
   constructor(DocumentData data);
   DocumentData get_data();
+  [Throws=Web5Error, Name=from_json_string]
+  constructor(string json);
+  [Throws=Web5Error]
+  string to_json_string();
 };
 
 enum ResolutionMetadataError {

--- a/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
+++ b/bindings/web5_uniffi_wrapper/src/dids/data_model/document.rs
@@ -1,4 +1,9 @@
-use web5::dids::data_model::document::Document as InnerDocument;
+use web5::{
+    dids::data_model::document::Document as InnerDocument,
+    json::{FromJson, ToJson},
+};
+
+use crate::errors::Result;
 
 pub struct Document(pub InnerDocument);
 
@@ -9,5 +14,13 @@ impl Document {
 
     pub fn get_data(&self) -> InnerDocument {
         self.0.clone()
+    }
+
+    pub fn from_json_string(json: String) -> Result<Self> {
+        Ok(Self(InnerDocument::from_json_string(&json)?))
+    }
+
+    pub fn to_json_string(&self) -> Result<String> {
+        Ok(self.0.to_json_string()?)
     }
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/Json.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/Json.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 internal const val dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
 
+// this is intended strictly for serializing data over the FFI, not for external use
 internal object Json {
     val jsonMapper: ObjectMapper = jacksonObjectMapper()
         .registerKotlinModule()

--- a/bound/kt/src/main/kotlin/web5/sdk/crypto/Dsa.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/crypto/Dsa.kt
@@ -1,0 +1,6 @@
+package web5.sdk.crypto
+
+enum class Dsa {
+    ED25519,
+    SECP256K1;
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/BearerDid.kt
@@ -28,7 +28,14 @@ class BearerDid private constructor(
     internal val rustCoreBearerDid: RustCoreBearerDid
 ) {
     constructor(did: Did, document: Document, keyManager: KeyManager) : this(
-        did, document, keyManager, RustCoreBearerDid(did.toRustCoreDidData(), document, ToInnerKeyManager(keyManager))
+        did,
+        document,
+        keyManager,
+        RustCoreBearerDid(
+            did.toRustCoreDidData(),
+            document.toRustCore(),
+            ToInnerKeyManager(keyManager)
+        )
     )
 
     companion object {
@@ -46,7 +53,7 @@ class BearerDid private constructor(
             val rustCoreBearerDidData = rustCoreBearerDid.getData()
             return BearerDid(
                 Did.fromRustCoreDidData(rustCoreBearerDidData.did),
-                rustCoreBearerDidData.document,
+                Document.fromRustCore(rustCoreBearerDidData.document),
                 ToOuterKeyManager(rustCoreBearerDidData.keyManager)
             )
         }

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/Document.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/Document.kt
@@ -1,8 +1,106 @@
 package web5.sdk.dids
 
-import web5.sdk.rust.DocumentData as RustCoreDocumentData
+import web5.sdk.crypto.keys.Jwk
 
 /**
  * Representation of a [DID Document](https://github.com/TBD54566975/web5-spec/blob/main/spec/did.md).
  */
-typealias Document = RustCoreDocumentData
+data class Document(
+    val id: String,
+    val context: List<String>?,
+    val controller: List<String>?,
+    val alsoKnownAs: List<String>?,
+    val verificationMethod: List<VerificationMethod>,
+    val authentication: List<String>?,
+    val assertionMethod: List<String>?,
+    val keyAgreement: List<String>?,
+    val capabilityInvocation: List<String>?,
+    val capabilityDelegation: List<String>?,
+    val service: List<Service>?
+) {
+    companion object {
+        fun fromJsonString(json: String): Document {
+            return fromRustCore(web5.sdk.rust.Document.fromJsonString(json).getData())
+        }
+
+        internal fun fromRustCore(document: web5.sdk.rust.DocumentData): Document {
+            return Document(
+                document.id,
+                document.context,
+                document.controller,
+                document.alsoKnownAs,
+                document.verificationMethod.map { VerificationMethod.fromRustCore(it) },
+                document.authentication,
+                document.assertionMethod,
+                document.keyAgreement,
+                document.capabilityInvocation,
+                document.capabilityDelegation,
+                document.service?.map { Service.fromRustCore(it) }
+            )
+        }
+    }
+
+    fun toJsonString(): String {
+        return web5.sdk.rust.Document(toRustCore()).toJsonString()
+    }
+
+    internal fun toRustCore(): web5.sdk.rust.DocumentData {
+        return web5.sdk.rust.DocumentData(
+            id,
+            context,
+            controller,
+            alsoKnownAs,
+            verificationMethod.map { it.toRustCore() },
+            authentication,
+            assertionMethod,
+            keyAgreement,
+            capabilityInvocation,
+            capabilityDelegation,
+            service?.map { it.toRustCore() }
+        )
+    }
+}
+
+data class VerificationMethod(
+    val id: String,
+    val type: String,
+    val controller: String,
+    val publicKeyJwk: Jwk
+) {
+    companion object {
+        internal fun fromRustCore(verificationMethod: web5.sdk.rust.VerificationMethodData): VerificationMethod {
+            return VerificationMethod(
+                verificationMethod.id,
+                verificationMethod.type,
+                verificationMethod.controller,
+                Jwk.fromRustCoreJwkData(verificationMethod.publicKeyJwk)
+            )
+        }
+    }
+
+    internal fun toRustCore(): web5.sdk.rust.VerificationMethodData {
+        return web5.sdk.rust.VerificationMethodData(
+            id, type, controller, publicKeyJwk.rustCoreJwkData
+        )
+    }
+}
+
+data class Service(
+    val id: String,
+    val type: String,
+    val serviceEndpoint: List<String>
+) {
+    companion object {
+        internal fun fromRustCore(service: web5.sdk.rust.ServiceData): Service {
+            return Service(
+                service.id,
+                service.type,
+                service.serviceEndpoint
+            )
+        }
+    }
+
+    internal fun toRustCore(): web5.sdk.rust.ServiceData {
+        return web5.sdk.rust.ServiceData(id, type, serviceEndpoint)
+    }
+}

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/PortableDid.kt
@@ -10,15 +10,22 @@ class PortableDid private constructor(
     internal val rustCorePortableDid: RustCorePortableDid
 ) {
     constructor(didUri: String, document: Document, privateKeys: List<Jwk>) : this(
-        didUri, document, privateKeys, RustCorePortableDid(didUri, document, privateKeys.map { it.rustCoreJwkData })
+        didUri,
+        document,
+        privateKeys,
+        RustCorePortableDid(
+            didUri,
+            document.toRustCore(),
+            privateKeys.map { it.rustCoreJwkData }
+        )
     )
 
-    /**
-     * Constructs a PortableDid from a JSON string.
-     *
-     * @param json The JSON string.
-     */
     companion object {
+        /**
+         * Constructs a PortableDid from a JSON string.
+         *
+         * @param json The JSON string.
+         */
         fun fromJsonString(json: String): PortableDid {
             val rustCorePortableDid = RustCorePortableDid.fromJsonString(json)
             return PortableDid.fromRustCorePortableDid(rustCorePortableDid)
@@ -28,7 +35,7 @@ class PortableDid private constructor(
             val data = rustCorePortableDid.getData()
             return PortableDid(
                 data.didUri,
-                data.document,
+                Document.fromRustCore(data.document),
                 data.privateJwks.map { Jwk.fromRustCoreJwkData(it) },
                 rustCorePortableDid
             )

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/ResolutionResult.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/ResolutionResult.kt
@@ -1,30 +1,86 @@
 package web5.sdk.dids
 
-import web5.sdk.rust.DocumentMetadataData
-import web5.sdk.rust.ResolutionMetadataData
-import web5.sdk.rust.ResolutionResult as RustCoreResolutionResult
-
-data class ResolutionResultResolveOptions(
-    val didDhtGatewayUrl: String? = null,
-)
-
 /**
  * Representation of the result of a DID (Decentralized Identifier) resolution.
  */
 class ResolutionResult(
     val document: Document? = null,
-    val documentMetadata: DocumentMetadataData? = null,
-    val resolutionMetadata: ResolutionMetadataData) {
+    val documentMetadata: DocumentMetadata? = null,
+    val resolutionMetadata: ResolutionMetadata) {
 
     companion object {
         fun resolve(uri: String): ResolutionResult {
-            val rustCoreResolutionResult = RustCoreResolutionResult.resolve(uri)
+            val rustCoreResolutionResult = web5.sdk.rust.ResolutionResult.resolve(uri)
             return ResolutionResult.fromRustCoreResolutionResult(rustCoreResolutionResult)
         }
 
-        internal fun fromRustCoreResolutionResult(rustCoreResolutionResult: RustCoreResolutionResult): ResolutionResult {
+        internal fun fromRustCoreResolutionResult(rustCoreResolutionResult: web5.sdk.rust.ResolutionResult): ResolutionResult {
             val data = rustCoreResolutionResult.getData()
-            return ResolutionResult(data.document, data.documentMetadata, data.resolutionMetadata)
+            return ResolutionResult(
+                data.document?.let { Document.fromRustCore(it) },
+                data.documentMetadata?.let { DocumentMetadata.fromRustCore(it) },
+                ResolutionMetadata.fromRustCore(data.resolutionMetadata)
+            )
         }
     }
+}
+
+data class DocumentMetadata(
+    val created: String?,
+    val updated: String?,
+    val deactivated: Boolean?,
+    val nextUpdate: String?,
+    val versionId: String?,
+    val nextVersionId: String?,
+    val equivalentId: List<String>?,
+    val canonicalId: String?
+) {
+    companion object {
+        internal fun fromRustCore(documentMetadata: web5.sdk.rust.DocumentMetadataData): DocumentMetadata {
+            return DocumentMetadata(
+                documentMetadata.created,
+                documentMetadata.updated,
+                documentMetadata.deactivated,
+                documentMetadata.nextUpdate,
+                documentMetadata.versionId,
+                documentMetadata.nextVersionId,
+                documentMetadata.equivalentId,
+                documentMetadata.canonicalId
+            )
+        }
+    }
+}
+
+data class ResolutionMetadata(
+    val error: ResolutionMetadataError?
+) {
+    companion object {
+        internal fun fromRustCore(resolutionMetadata: web5.sdk.rust.ResolutionMetadataData): ResolutionMetadata {
+            return ResolutionMetadata(
+                resolutionMetadata.error?.let {
+                    when (it) {
+                        web5.sdk.rust.ResolutionMetadataError.INVALID_DID -> ResolutionMetadataError.INVALID_DID
+                        web5.sdk.rust.ResolutionMetadataError.NOT_FOUND -> ResolutionMetadataError.NOT_FOUND
+                        web5.sdk.rust.ResolutionMetadataError.REPRESENTATION_NOT_SUPPORTED -> ResolutionMetadataError.REPRESENTATION_NOT_SUPPORTED
+                        web5.sdk.rust.ResolutionMetadataError.METHOD_NOT_SUPPORTED -> ResolutionMetadataError.METHOD_NOT_SUPPORTED
+                        web5.sdk.rust.ResolutionMetadataError.INVALID_DID_DOCUMENT -> ResolutionMetadataError.INVALID_DID_DOCUMENT
+                        web5.sdk.rust.ResolutionMetadataError.INVALID_PUBLIC_KEY -> ResolutionMetadataError.INVALID_PUBLIC_KEY
+                        web5.sdk.rust.ResolutionMetadataError.INVALID_DID_DOCUMENT_LENGTH -> ResolutionMetadataError.INVALID_DID_DOCUMENT_LENGTH
+                        web5.sdk.rust.ResolutionMetadataError.INTERNAL_ERROR -> ResolutionMetadataError.INTERNAL_ERROR
+                    }
+                }
+            )
+        }
+    }
+}
+
+enum class ResolutionMetadataError {
+    INVALID_DID,
+    NOT_FOUND,
+    REPRESENTATION_NOT_SUPPORTED,
+    METHOD_NOT_SUPPORTED,
+    INVALID_DID_DOCUMENT,
+    INVALID_PUBLIC_KEY,
+    INVALID_DID_DOCUMENT_LENGTH,
+    INTERNAL_ERROR;
 }

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -4,26 +4,18 @@ import web5.sdk.crypto.keys.KeyManager
 import web5.sdk.crypto.keys.ToInnerKeyManager
 import web5.sdk.dids.BearerDid
 import web5.sdk.dids.ResolutionResult
-import web5.sdk.rust.ServiceData
-import web5.sdk.rust.VerificationMethodData
+import web5.sdk.dids.Service
+import web5.sdk.dids.VerificationMethod
 import web5.sdk.rust.didDhtResolve as rustCoreDidDhtResolve
 
 data class DidDhtCreateOptions(
     val publish: Boolean? = true,
     val gatewayUrl: String? = null,
     val keyManager: KeyManager? = null,
-    val service: List<ServiceData>? = null,
+    val service: List<Service>? = null,
     val controller: List<String>? = null,
     val alsoKnownAs: List<String>? = null,
-    val verificationMethod: List<VerificationMethodData>? = null
-)
-
-data class DidDhtPublishOptions(
-    val gatewayUrl: String? = null
-)
-
-data class DidDhtResolveOptions(
-    val gatewayUrl: String? = null
+    val verificationMethod: List<VerificationMethod>? = null
 )
 
 /**
@@ -42,10 +34,10 @@ class DidDht {
                     opts.publish,
                     opts.gatewayUrl,
                     opts.keyManager?.let { ToInnerKeyManager(it) },
-                    opts.service,
+                    opts.service?.map { it.toRustCore() },
                     opts.controller,
                     opts.alsoKnownAs,
-                    opts.verificationMethod
+                    opts.verificationMethod?.map { it.toRustCore() }
                 )
             }
             val rustCoreBearerDid = web5.sdk.rust.didDhtCreate(rustCoreOptions)
@@ -56,7 +48,7 @@ class DidDht {
          * Publish a DidDht BearerDid using available options.
          *
          * @param bearerDid The DidDht BearerDid instance to publish.
-         * @param options The set of options to configure publish.
+         * @param gatewayUrl The optional gateway URL to publish to.
          */
         fun publish(bearerDid: BearerDid, gatewayUrl: String? = null) {
            web5.sdk.rust.didDhtPublish(bearerDid.rustCoreBearerDid, gatewayUrl)
@@ -66,7 +58,7 @@ class DidDht {
          * Resolves a DID URI to a DidResolutionResult.
          *
          * @param uri The DID URI to resolve.
-         * @return DidResolutionResult The result of the DID resolution.
+         * @param gatewayUrl The optional gateway URL to resolve from.
          */
         @JvmStatic
         fun resolve(uri: String, gatewayUrl: String? = null): ResolutionResult {

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -2,7 +2,6 @@ package web5.sdk.dids.methods.jwk
 
 import web5.sdk.crypto.keys.KeyManager
 import web5.sdk.crypto.keys.ToInnerKeyManager
-import web5.sdk.crypto.keys.ToOuterKeyManager
 import web5.sdk.dids.BearerDid
 import web5.sdk.dids.ResolutionResult
 import web5.sdk.rust.Dsa

--- a/bound/kt/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
@@ -4,19 +4,19 @@ import web5.sdk.crypto.keys.KeyManager
 import web5.sdk.crypto.keys.ToInnerKeyManager
 import web5.sdk.dids.BearerDid
 import web5.sdk.dids.ResolutionResult
+import web5.sdk.dids.Service
+import web5.sdk.dids.VerificationMethod
 import web5.sdk.rust.Dsa
-import web5.sdk.rust.ServiceData
-import web5.sdk.rust.VerificationMethodData
 import web5.sdk.rust.didWebCreate as rustCoreDidWebCreate
 import web5.sdk.rust.didWebResolve as rustCoreDidWebResolve
 
 data class DidWebCreateOptions(
     val keyManager: KeyManager? = null,
     val dsa: Dsa? = null,
-    val service: List<ServiceData>? = null,
+    val service: List<Service>? = null,
     val controller: List<String>? = null,
     val alsoKnownAs: List<String>? = null,
-    val verificationMethod: List<VerificationMethodData>? = null
+    val verificationMethod: List<VerificationMethod>? = null
 )
 
 /**
@@ -35,10 +35,10 @@ class DidWeb {
                 web5.sdk.rust.DidWebCreateOptions(
                     keyManager = opts.keyManager?.let { ToInnerKeyManager(it) },
                     dsa = opts.dsa,
-                    service = opts.service,
+                    service = opts.service?.map { it.toRustCore() },
                     controller = opts.controller,
                     alsoKnownAs = opts.alsoKnownAs,
-                    verificationMethod = opts.verificationMethod
+                    verificationMethod = opts.verificationMethod?.map { it.toRustCore() }
                 )
             }
             val rustCoreBearerDid = rustCoreDidWebCreate(domain, rustCoreOptions)

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -897,6 +897,10 @@ internal open class UniffiVTableCallbackInterfaceVerifier(
 
 
 
+
+
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -946,9 +950,13 @@ internal interface UniffiLib : Library {
     ): Pointer
     fun uniffi_web5_uniffi_fn_free_document(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    fun uniffi_web5_uniffi_fn_constructor_document_from_json_string(`json`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Pointer
     fun uniffi_web5_uniffi_fn_constructor_document_new(`data`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_web5_uniffi_fn_method_document_get_data(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    fun uniffi_web5_uniffi_fn_method_document_to_json_string(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_clone_ed25519signer(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
@@ -1216,6 +1224,8 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_method_document_get_data(
     ): Short
+    fun uniffi_web5_uniffi_checksum_method_document_to_json_string(
+    ): Short
     fun uniffi_web5_uniffi_checksum_method_ed25519signer_sign(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_ed25519verifier_verify(
@@ -1259,6 +1269,8 @@ internal interface UniffiLib : Library {
     fun uniffi_web5_uniffi_checksum_constructor_bearerdid_new(
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_did_new(
+    ): Short
+    fun uniffi_web5_uniffi_checksum_constructor_document_from_json_string(
     ): Short
     fun uniffi_web5_uniffi_checksum_constructor_document_new(
     ): Short
@@ -1336,6 +1348,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_web5_uniffi_checksum_method_document_get_data() != 16490.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_web5_uniffi_checksum_method_document_to_json_string() != 29709.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_web5_uniffi_checksum_method_ed25519signer_sign() != 7079.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1400,6 +1415,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_constructor_did_new() != 60730.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_web5_uniffi_checksum_constructor_document_from_json_string() != 35057.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_constructor_document_new() != 10173.toShort()) {
@@ -2284,6 +2302,8 @@ public interface DocumentInterface {
     
     fun `getData`(): DocumentData
     
+    fun `toJsonString`(): kotlin.String
+    
     companion object
 }
 
@@ -2388,10 +2408,35 @@ open class Document: Disposable, AutoCloseable, DocumentInterface {
     
 
     
+    @Throws(Web5Exception::class)override fun `toJsonString`(): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_document_to_json_string(
+        it, _status)
+}
+    }
+    )
+    }
+    
 
     
+
     
-    companion object
+    companion object {
+        
+    @Throws(Web5Exception::class) fun `fromJsonString`(`json`: kotlin.String): Document {
+            return FfiConverterTypeDocument.lift(
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_constructor_document_from_json_string(
+        FfiConverterString.lower(`json`),_status)
+}
+    )
+    }
+    
+
+        
+    }
     
 }
 

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/ResolutionResultTests.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/ResolutionResultTests.kt
@@ -1,19 +1,14 @@
 package web5.sdk.dids
 
-import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.fail
-import web5.sdk.Json
 import web5.sdk.UnitTestSuite
-import web5.sdk.dids.methods.dht.DidDht
-import web5.sdk.dids.methods.dht.DidDhtCreateOptions
 import web5.sdk.dids.methods.jwk.DidJwk
 import web5.sdk.dids.methods.web.DidWeb
-import web5.sdk.rust.ResolutionMetadataError
+import web5.sdk.dids.ResolutionMetadataError
 
 class ResolutionResultTests {
     @Nested
@@ -60,14 +55,11 @@ class ResolutionResultTests {
 
             val bearerDid = DidWeb.create(url.toString())
 
-            // temporarily removing @context from document, need to rework Document type
-            bearerDid.document.context = null
-
             mockWebServer.enqueue(
                 MockResponse()
                     .setResponseCode(200)
                     .addHeader("Content-Type", "application/json")
-                    .setBody(Json.stringify(bearerDid.document))
+                    .setBody(bearerDid.document.toJsonString())
             )
 
             val resolutionResult = ResolutionResult.resolve(bearerDid.did.uri)

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTests.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTests.kt
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.fail
 import web5.sdk.UnitTestSuite
 import web5.sdk.crypto.keys.InMemoryKeyManager
 import web5.sdk.crypto.keys.Jwk
+import web5.sdk.dids.Service
+import web5.sdk.dids.VerificationMethod
+import web5.sdk.dids.ResolutionMetadataError
 import web5.sdk.rust.*
 
 class DidDhtTests {
@@ -41,7 +44,7 @@ class DidDhtTests {
 
             val publicJwk = bearerDid.document.verificationMethod.first().publicKeyJwk
             assertDoesNotThrow {
-                keyManager.getSigner(Jwk.fromRustCoreJwkData(publicJwk))
+                keyManager.getSigner(publicJwk)
             }
         }
 
@@ -80,11 +83,11 @@ class DidDhtTests {
         fun test_should_add_optional_verification_methods() {
             testSuite.include()
 
-            val additionalVerificationMethod = VerificationMethodData(
+            val additionalVerificationMethod = VerificationMethod(
                 id = "did:web:example.com#key-1",
                 type = "JsonWebKey",
                 controller = "did:web:example.com",
-                publicKeyJwk = JwkData(
+                publicKeyJwk = Jwk(
                     kty = "OKP",
                     crv = "Ed25519",
                     x = "some pub value",
@@ -109,7 +112,7 @@ class DidDhtTests {
         fun test_should_add_optional_services() {
             testSuite.include()
 
-            val service = ServiceData(
+            val service = Service(
                 id = "did:web:example.com#service-0",
                 type = "SomeService",
                 serviceEndpoint = listOf("https://example.com/service")

--- a/bound/kt/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTests.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTests.kt
@@ -5,9 +5,8 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.fail
 import web5.sdk.UnitTestSuite
 import web5.sdk.crypto.keys.InMemoryKeyManager
-import web5.sdk.crypto.keys.Jwk
+import web5.sdk.dids.ResolutionMetadataError
 import web5.sdk.rust.Dsa
-import web5.sdk.rust.ResolutionMetadataError
 
 class DidJwkTests {
     @Nested
@@ -34,7 +33,7 @@ class DidJwkTests {
             // TODO publicKeyJwk on the document should be of type Jwk
             val publicJwk = bearerDid.document.verificationMethod.first().publicKeyJwk
             assertDoesNotThrow {
-                keyManager.getSigner(Jwk.fromRustCoreJwkData(publicJwk))
+                keyManager.getSigner(publicJwk)
             }
         }
 

--- a/crates/web5/src/dids/data_model/document.rs
+++ b/crates/web5/src/dids/data_model/document.rs
@@ -1,5 +1,8 @@
 use super::{service::Service, verification_method::VerificationMethod};
-use crate::errors::{Result, Web5Error};
+use crate::{
+    errors::{Result, Web5Error},
+    json::{FromJson, ToJson},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -32,6 +35,9 @@ pub struct Document {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service: Option<Vec<Service>>,
 }
+
+impl FromJson for Document {}
+impl ToJson for Document {}
 
 pub(crate) struct FindVerificationMethodOptions {
     pub verification_method_id: Option<String>,

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -12,7 +12,10 @@
       - [`VerifiableCredential`](#verifiablecredential)
         - [`CredentialSubject`](#credentialsubject)
         - [`Issuer`](#issuer)
+        - [`CredentialStatus`](#credentialstatus)
         - [`CreateOptions`](#createoptions)
+  - [StatusListCredential](#statuslistcredential)
+      - [`StatusListCredential`](#statuslistcredential-1)
   - [Presentation Exchange (PEX)](#presentation-exchange-pex)
     - [`PresentationDefinition`](#presentationdefinition)
     - [`InputDescriptor`](#inputdescriptor)
@@ -533,6 +536,10 @@ CLASS Document
   ///
   /// [Specification Reference](https://www.w3.org/TR/did-core/#services)
   PUBLIC DATA service: []Service?
+
+  CONSTRUCTOR from_json_string(json: string)
+
+  METHOD to_json_string(): string
 ```
 
 ### `VerificationMethod`


### PR DESCRIPTION
This way we aren't tightly coupled with what UniFFI codegens

Also added `from_json_string` and `to_json_string` to the DID Document 