### PR TITLE
Build CLI binaries and attach them to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           files: web5_cli-aarch64-apple-darwin
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-  build_x86_64_apple_darwin:
+  build_cli_x86_64_apple_darwin:
     runs-on: macos-12
     name: x86_64-apple-darwin
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: Build web5_cli release artifacts
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build_cli_aarch64-apple-darwin:
+    runs-on: macos-latest
+    name: aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup toolchain install stable
+      - name: cargo build
+        run: |
+          cargo build --target aarch64-apple-darwin --release --package web5_cli
+          cp -v target/aarch64-apple-darwin/release/web5_cli web5_cli-aarch64-apple-darwin
+      - name: upload release asset
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: web5_cli-aarch64-apple-darwin
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_x86_64_apple_darwin:
+    runs-on: macos-12
+    name: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup toolchain install stable
+      - name: cargo build
+        run: |
+          cargo build --target x86_64-apple-darwin --release --package web5_cli --features x86_64_apple_darwin
+          cp -v target/x86_64-apple-darwin/release/web5_cli web5_cli-x86_64-apple-darwin
+      - name: upload release asset
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: web5_cli-x86_64-apple-darwin
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_cli_x86_64_unknown_linux_gnu:
+    runs-on: ubuntu-latest
+    name: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v2
+      - name: cargo build
+        run: |
+          cargo build --target x86_64-unknown-linux-gnu --release --package web5_cli
+          cp -v target/x86_64-unknown-linux-gnu/release/web5_cli web5_cli-x86_64-unknown-linux-gnu
+      - name: upload release asset
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: web5_cli-x86_64-unknown-linux-gnu
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_cli_x86_64_unknown_linux_musl:
+    runs-on: ubuntu-latest
+    name: x86_64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build Script
+        run: |
+          pushd crates/web5_cli/build/x86_64_unknown_linux_musl
+          ./build
+          popd
+          cp target/x86_64-unknown-linux-musl/release/web5_cli web5_cli-x86_64-unknown-linux-musl
+      - name: upload release asset
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: web5_cli-x86_64-unknown-linux-musl
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,8 +9,9 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*       @KendallWeihe @nitro-neal @kirahsapong @shamilovtim @diehuxx @decentralgabe @frankhinek @leordev @ALRubinger
+*                               @KendallWeihe @nitro-neal @kirahsapong @shamilovtim @diehuxx @decentralgabe @frankhinek @leordev @ALRubinger
 
+.github/workflows/release.yaml  @finn-tbd
 
 # -----------------------------------------------
 # BELOW THIS LINE ARE TEMPLATES, UNUSED

--- a/crates/web5_cli/install.sh
+++ b/crates/web5_cli/install.sh
@@ -12,14 +12,14 @@ ARCH=$(uname -m)
 case $OS in
   "linux")
     case $ARCH in
-      "x86_64") FILENAME="web5-x86_64-linux-gnu.zip" ;;
+      "x86_64") FILENAME="web5-x86_64-linux-gnu" ;;
       *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
     esac
     ;;
   "darwin")
     case $ARCH in
-      "x86_64") FILENAME="web5-x86_64-apple-darwin.zip" ;;
-      "arm64") FILENAME="web5-aarch64-apple-darwin.zip" ;;
+      "x86_64") FILENAME="web5-x86_64-apple-darwin" ;;
+      "arm64") FILENAME="web5-aarch64-apple-darwin" ;;
       *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
     esac
     ;;
@@ -27,13 +27,14 @@ case $OS in
     echo "Unsupported OS: $OS"; exit 1 ;;
 esac
 
-# Download and unzip
+# Download
 curl -L -o /tmp/$FILENAME https://github.com/TBD54566975/web5-rs/releases/download/$VERSION/$FILENAME
-unzip -o /tmp/$FILENAME -d /tmp
 
-# Move the executable to /usr/local/bin and make it executable
-sudo mv /tmp/web5_cli /usr/local/bin/web5
-sudo chmod +x /usr/local/bin/web5
+# give it executable permissions
+chmod +x /tmp/$FILENAME
+
+# Move the executable to /usr/local/bin
+sudo mv /tmp/$FILENAME /usr/local/bin/web5
 
 # Cleanup
 rm /tmp/$FILENAME


### PR DESCRIPTION
This adds GitHub Action jobs that build cli binaries when a release is created and attaches them to the release. You can see what this looks like on the [latest test release in my branch](https://github.com/finn-tbd/web5-rs/releases/tag/v0.1.4). To use it, simply create a release and the automation will take care of the rest.