### PR TITLE
Removing ALRubinger from `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*                               @KendallWeihe @nitro-neal @kirahsapong @shamilovtim @diehuxx @decentralgabe @frankhinek @leordev @ALRubinger
+*                               @KendallWeihe @nitro-neal @kirahsapong @shamilovtim @diehuxx @decentralgabe @frankhinek @leordev
 
 .github/workflows/release.yaml  @finn-tbd
 


### PR DESCRIPTION
May explicitly ask for review where needed