### PR TITLE
Change XML datetimes to 'Z' notation from '+00:00'

### DIFF
--- a/crates/web5/src/rfc3339.rs
+++ b/crates/web5/src/rfc3339.rs
@@ -10,7 +10,7 @@ where
     S: Serializer,
 {
     let datetime: chrono::DateTime<Utc> = (*time).into();
-    let s = datetime.to_rfc3339();
+    let s = datetime.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     serializer.serialize_str(&s)
 }
 


### PR DESCRIPTION
Previously we were serializing rfc3339 datetimes via the `+00:00` timezone offset notation, but the `Z` offset notation is more common. Both are conformant, but it's better to roll with the more common. Good news is our `rfc3339` module supports both without errors, but this way when we create JSON objects it's using the more common format.

Here's a little unit test I wrote

```rust
#[test]
fn test_tmp_kweihe() {
    let bearer_did = crate::dids::methods::did_jwk::DidJwk::create(None).unwrap();
    let issuer = crate::credentials::Issuer::from(bearer_did.did.uri.clone());
    let credential_subject = crate::credentials::CredentialSubject::from(
        crate::dids::methods::did_jwk::DidJwk::create(None)
            .unwrap()
            .did
            .uri,
    );

    let vc =
        crate::credentials::VerifiableCredential::create(issuer, credential_subject, None)
            .unwrap();

    let vc_jwt = vc.sign(&bearer_did, None).unwrap();
    println!("{}", vc_jwt);
}
```

And that produced this:

```
eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSjFUR3BaZEVnNGFuaGllVEZaYWpCbFZsTmxaazlvTkhGVWVVdDBjRzAyTm1OT1RFeFlVR2haWW5jd0luMCMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJpZCI6InVybjp1dWlkOjk5MzdjYzViLTgyOWMtNGRiMy05ZTAzLTY4NDU2ZmExMDUxMCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOmp3azpleUpoYkdjaU9pSkZaREkxTlRFNUlpd2lhM1I1SWpvaVQwdFFJaXdpWTNKMklqb2lSV1F5TlRVeE9TSXNJbmdpT2lKMVRHcFpkRWc0YW5oaWVURlphakJsVmxObFprOW9OSEZVZVV0MGNHMDJObU5PVEV4WVVHaFpZbmN3SW4wIiwiaXNzdWFuY2VEYXRlIjoiMjAyNC0wOS0wNVQyMTo0Mzo0OFoiLCJleHBpcmF0aW9uRGF0ZSI6bnVsbCwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlpESTFOVEU1SWl3aWEzUjVJam9pVDB0UUlpd2lZM0oySWpvaVJXUXlOVFV4T1NJc0luZ2lPaUpQWTBSemVqUm5iakIyY1dGTk1WRnVUREoyWjFjMU5HUlRaR3RUVTIxeFdHNWlNV1ZHVkZGdVNGZHpJbjAifX0sImlzcyI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSjFUR3BaZEVnNGFuaGllVEZaYWpCbFZsTmxaazlvTkhGVWVVdDBjRzAyTm1OT1RFeFlVR2haWW5jd0luMCIsImp0aSI6InVybjp1dWlkOjk5MzdjYzViLTgyOWMtNGRiMy05ZTAzLTY4NDU2ZmExMDUxMCIsInN1YiI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSlBZMFJ6ZWpSbmJqQjJjV0ZOTVZGdVRESjJaMWMxTkdSVFpHdFRVMjF4V0c1aU1XVkdWRkZ1U0ZkekluMCIsIm5iZiI6MTcyNTU3MjYyOCwiaWF0IjoxNzI1NTcyNjI4fQ.yIR10NyK2oFz_QqBz0fdRyg4DTfdYkfupmBV9KGS72AzVc72O3UHwlcjD3IJ70ikC4R0cQq0nXrkWlrXryiDDg
```

And decoding that I'm now seeing `2024-08-27T20:47:25.119624+00:00`