### PR TITLE
implementation of create_presentation_from_credentials

### DIFF
--- a/bindings/web5_uniffi/src/lib.rs
+++ b/bindings/web5_uniffi/src/lib.rs
@@ -10,7 +10,7 @@ use web5_uniffi_wrapper::{
         verifiable_presentation_1_1::{
             VerifiablePresentation,
             VerifiablePresentationCreateOptions as VerifiablePresentationCreateOptionsData,
-            VerifiablePresentationData
+            VerifiablePresentationData,
         },
     },
     crypto::{

--- a/bindings/web5_uniffi/src/lib.rs
+++ b/bindings/web5_uniffi/src/lib.rs
@@ -7,7 +7,11 @@ use web5_uniffi_wrapper::{
             VerifiableCredentialCreateOptions as VerifiableCredentialCreateOptionsData,
             VerifiableCredentialData,
         },
-        verifiable_presentation_1_1::VerifiablePresentation,
+        verifiable_presentation_1_1::{
+            VerifiablePresentation,
+            VerifiablePresentationCreateOptions as VerifiablePresentationCreateOptionsData,
+            VerifiablePresentationData
+        },
     },
     crypto::{
         dsa::{
@@ -37,8 +41,6 @@ use web5_uniffi_wrapper::{
 use web5::{
     credentials::{
         CredentialSchema as CredentialSchemaData, CredentialStatus as CredentialStatusData,
-        VerifiablePresentation as VerifiablePresentationData,
-        VerifiablePresentationCreateOptions as VerifiablePresentationCreateOptionsData,
     },
     crypto::{dsa::Dsa, jwk::Jwk as JwkData},
     dids::{

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -323,6 +323,7 @@ dictionary VerifiablePresentationCreateOptionsData {
   sequence<string>? type;
   timestamp? issuance_date;
   timestamp? expiration_date;
+  string? json_serialized_additional_data;
 };
 
 interface VerifiablePresentation {
@@ -351,4 +352,5 @@ dictionary VerifiablePresentationData {
   timestamp issuance_date;
   timestamp? expiration_date;
   sequence<string> verifiable_credential;
+  string? json_serialized_additional_data;
 };

--- a/bindings/web5_uniffi/src/web5.udl
+++ b/bindings/web5_uniffi/src/web5.udl
@@ -245,11 +245,9 @@ interface PresentationDefinition {
   string get_json_serialized_presentation_definition();
   [Throws=Web5Error]
   sequence<string> select_credentials([ByRef] sequence<string> vc_jwts);
+  [Throws=Web5Error]
+  string create_presentation_from_credentials([ByRef] sequence<string> vc_jwts);
 };
-
-
-
-
 
 dictionary VerifiableCredentialCreateOptionsData {
   string? id;

--- a/bindings/web5_uniffi_wrapper/src/credentials/presentation_definition.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/presentation_definition.rs
@@ -16,6 +16,13 @@ impl PresentationDefinition {
         Ok(self.0.select_credentials(vc_jwts)?)
     }
 
+    pub fn create_presentation_from_credentials(&self, vc_jwts: &Vec<String>) -> Result<String> {
+        let presentation_result = self.0.create_presentation_from_credentials(vc_jwts)?;
+        let json_serialized_presentation_result = serde_json::to_string(&presentation_result)?;
+
+        Ok(json_serialized_presentation_result)
+    }
+
     pub fn get_json_serialized_presentation_definition(&self) -> Result<String> {
         let json_serialized_presentation_definition = serde_json::to_string(&self.0)?;
 

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_presentation_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_presentation_1_1.rs
@@ -5,10 +5,6 @@ use std::time::SystemTime;
 use serde_json::Value;
 use web5::credentials::VerifiablePresentation as InnerVerifiablePresentation;
 use web5::credentials::VerifiablePresentationCreateOptions as InnerVerifiablePresentationCreateOptions;
-use web5::{
-    json::{FromJson as _, JsonObject},
-};
-// use web5::json::JsonObject;
 
 #[derive(Default)]
 pub struct VerifiablePresentationCreateOptions {

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_presentation_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_presentation_1_1.rs
@@ -1,7 +1,24 @@
+use std::collections::HashMap;
 use crate::{dids::bearer_did::BearerDid, errors::Result};
 use std::sync::Arc;
+use std::time::SystemTime;
+use serde_json::Value;
 use web5::credentials::VerifiablePresentation as InnerVerifiablePresentation;
-use web5::credentials::VerifiablePresentationCreateOptions;
+use web5::credentials::VerifiablePresentationCreateOptions as InnerVerifiablePresentationCreateOptions;
+use web5::{
+    json::{FromJson as _, JsonObject},
+};
+// use web5::json::JsonObject;
+
+#[derive(Default)]
+pub struct VerifiablePresentationCreateOptions {
+    pub id: Option<String>,
+    pub context: Option<Vec<String>>,
+    pub r#type: Option<Vec<String>>,
+    pub issuance_date: Option<SystemTime>,
+    pub expiration_date: Option<SystemTime>,
+    pub json_serialized_additional_data: Option<String>,
+}
 
 pub struct VerifiablePresentation {
     pub inner_vp: InnerVerifiablePresentation,
@@ -13,13 +30,37 @@ impl VerifiablePresentation {
         vc_jwts: Vec<String>,
         options: Option<VerifiablePresentationCreateOptions>,
     ) -> Result<Self> {
-        let inner_vp = InnerVerifiablePresentation::create(holder, vc_jwts, options)?;
+
+        let options = options.unwrap_or_default();
+
+        let additional_data = match options.json_serialized_additional_data {
+            Some(additional_data) => {
+                Some(serde_json::from_str::<HashMap<String,Value>>(&additional_data)?)
+            }
+            None => None,
+        };
+
+        let inner_options = InnerVerifiablePresentationCreateOptions {
+            id: options.id,
+            context: options.context,
+            r#type: options.r#type,
+            issuance_date: options.issuance_date,
+            expiration_date: options.expiration_date,
+            additional_data: additional_data,
+        };
+
+        let inner_vp = InnerVerifiablePresentation::create(holder, vc_jwts, Some(inner_options))?;
 
         Ok(Self { inner_vp })
     }
 
-    pub fn get_data(&self) -> Result<InnerVerifiablePresentation> {
-        Ok(InnerVerifiablePresentation {
+    pub fn get_data(&self) -> Result<VerifiablePresentationData> {
+        let json_serialized_additional_data = match &self.inner_vp.additional_data {
+            Some(e) => Some(serde_json::to_string(e)?),
+            None => None,
+        };
+
+        Ok(VerifiablePresentationData {
             context: self.inner_vp.context.clone(),
             id: self.inner_vp.id.clone(),
             r#type: self.inner_vp.r#type.clone(),
@@ -27,6 +68,7 @@ impl VerifiablePresentation {
             verifiable_credential: self.inner_vp.verifiable_credential.clone(),
             issuance_date: self.inner_vp.issuance_date,
             expiration_date: self.inner_vp.expiration_date,
+            json_serialized_additional_data: json_serialized_additional_data,
         })
     }
 
@@ -44,4 +86,16 @@ impl VerifiablePresentation {
         let vp_jwt = self.inner_vp.sign(&bearer_did.0, verification_method_id)?;
         Ok(vp_jwt)
     }
+}
+
+#[derive(Clone)]
+pub struct VerifiablePresentationData {
+    pub context: Vec<String>,
+    pub id: String,
+    pub r#type: Vec<String>,
+    pub holder: String,
+    pub issuance_date: SystemTime,
+    pub expiration_date: Option<SystemTime>,
+    pub verifiable_credential: Vec<String>,
+    pub json_serialized_additional_data: Option<String>,
 }

--- a/bindings/web5_uniffi_wrapper/src/credentials/verifiable_presentation_1_1.rs
+++ b/bindings/web5_uniffi_wrapper/src/credentials/verifiable_presentation_1_1.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
 use crate::{dids::bearer_did::BearerDid, errors::Result};
+use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
-use serde_json::Value;
 use web5::credentials::VerifiablePresentation as InnerVerifiablePresentation;
 use web5::credentials::VerifiablePresentationCreateOptions as InnerVerifiablePresentationCreateOptions;
 
@@ -26,13 +26,12 @@ impl VerifiablePresentation {
         vc_jwts: Vec<String>,
         options: Option<VerifiablePresentationCreateOptions>,
     ) -> Result<Self> {
-
         let options = options.unwrap_or_default();
 
         let additional_data = match options.json_serialized_additional_data {
-            Some(additional_data) => {
-                Some(serde_json::from_str::<HashMap<String,Value>>(&additional_data)?)
-            }
+            Some(additional_data) => Some(serde_json::from_str::<HashMap<String, Value>>(
+                &additional_data,
+            )?),
             None => None,
         };
 
@@ -42,7 +41,7 @@ impl VerifiablePresentation {
             r#type: options.r#type,
             issuance_date: options.issuance_date,
             expiration_date: options.expiration_date,
-            additional_data: additional_data,
+            additional_data,
         };
 
         let inner_vp = InnerVerifiablePresentation::create(holder, vc_jwts, Some(inner_options))?;
@@ -64,7 +63,7 @@ impl VerifiablePresentation {
             verifiable_credential: self.inner_vp.verifiable_credential.clone(),
             issuance_date: self.inner_vp.issuance_date,
             expiration_date: self.inner_vp.expiration_date,
-            json_serialized_additional_data: json_serialized_additional_data,
+            json_serialized_additional_data,
         })
     }
 

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -923,6 +923,8 @@ internal open class UniffiVTableCallbackInterfaceVerifier(
 
 
 
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -1056,6 +1058,8 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_web5_uniffi_fn_constructor_presentationdefinition_new(`jsonSerializedPresentationDefinition`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
+    fun uniffi_web5_uniffi_fn_method_presentationdefinition_create_presentation_from_credentials(`ptr`: Pointer,`vcJwts`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_method_presentationdefinition_get_json_serialized_presentation_definition(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_web5_uniffi_fn_method_presentationdefinition_select_credentials(`ptr`: Pointer,`vcJwts`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1300,6 +1304,8 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_web5_uniffi_checksum_method_portabledid_to_json_string(
     ): Short
+    fun uniffi_web5_uniffi_checksum_method_presentationdefinition_create_presentation_from_credentials(
+    ): Short
     fun uniffi_web5_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition(
     ): Short
     fun uniffi_web5_uniffi_checksum_method_presentationdefinition_select_credentials(
@@ -1454,6 +1460,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_method_portabledid_to_json_string() != 53673.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_web5_uniffi_checksum_method_presentationdefinition_create_presentation_from_credentials() != 27580.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_web5_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition() != 52261.toShort()) {
@@ -4548,6 +4557,8 @@ public object FfiConverterTypePortableDid: FfiConverter<PortableDid, Pointer> {
 
 public interface PresentationDefinitionInterface {
     
+    fun `createPresentationFromCredentials`(`vcJwts`: List<kotlin.String>): kotlin.String
+    
     fun `getJsonSerializedPresentationDefinition`(): kotlin.String
     
     fun `selectCredentials`(`vcJwts`: List<kotlin.String>): List<kotlin.String>
@@ -4642,6 +4653,19 @@ open class PresentationDefinition: Disposable, AutoCloseable, PresentationDefini
             UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_clone_presentationdefinition(pointer!!, status)
         }
     }
+
+    
+    @Throws(Web5Exception::class)override fun `createPresentationFromCredentials`(`vcJwts`: List<kotlin.String>): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCallWithError(Web5Exception) { _status ->
+    UniffiLib.INSTANCE.uniffi_web5_uniffi_fn_method_presentationdefinition_create_presentation_from_credentials(
+        it, FfiConverterSequenceString.lower(`vcJwts`),_status)
+}
+    }
+    )
+    }
+    
 
     
     @Throws(Web5Exception::class)override fun `getJsonSerializedPresentationDefinition`(): kotlin.String {

--- a/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/web5/sdk/rust/UniFFI.kt
@@ -7022,7 +7022,8 @@ data class VerifiablePresentationCreateOptionsData (
     var `context`: List<kotlin.String>?, 
     var `type`: List<kotlin.String>?, 
     var `issuanceDate`: java.time.Instant?, 
-    var `expirationDate`: java.time.Instant?
+    var `expirationDate`: java.time.Instant?, 
+    var `jsonSerializedAdditionalData`: kotlin.String?
 ) {
     
     companion object
@@ -7036,6 +7037,7 @@ public object FfiConverterTypeVerifiablePresentationCreateOptionsData: FfiConver
             FfiConverterOptionalSequenceString.read(buf),
             FfiConverterOptionalTimestamp.read(buf),
             FfiConverterOptionalTimestamp.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
@@ -7044,7 +7046,8 @@ public object FfiConverterTypeVerifiablePresentationCreateOptionsData: FfiConver
             FfiConverterOptionalSequenceString.allocationSize(value.`context`) +
             FfiConverterOptionalSequenceString.allocationSize(value.`type`) +
             FfiConverterOptionalTimestamp.allocationSize(value.`issuanceDate`) +
-            FfiConverterOptionalTimestamp.allocationSize(value.`expirationDate`)
+            FfiConverterOptionalTimestamp.allocationSize(value.`expirationDate`) +
+            FfiConverterOptionalString.allocationSize(value.`jsonSerializedAdditionalData`)
     )
 
     override fun write(value: VerifiablePresentationCreateOptionsData, buf: ByteBuffer) {
@@ -7053,6 +7056,7 @@ public object FfiConverterTypeVerifiablePresentationCreateOptionsData: FfiConver
             FfiConverterOptionalSequenceString.write(value.`type`, buf)
             FfiConverterOptionalTimestamp.write(value.`issuanceDate`, buf)
             FfiConverterOptionalTimestamp.write(value.`expirationDate`, buf)
+            FfiConverterOptionalString.write(value.`jsonSerializedAdditionalData`, buf)
     }
 }
 
@@ -7065,7 +7069,8 @@ data class VerifiablePresentationData (
     var `holder`: kotlin.String, 
     var `issuanceDate`: java.time.Instant, 
     var `expirationDate`: java.time.Instant?, 
-    var `verifiableCredential`: List<kotlin.String>
+    var `verifiableCredential`: List<kotlin.String>, 
+    var `jsonSerializedAdditionalData`: kotlin.String?
 ) {
     
     companion object
@@ -7081,6 +7086,7 @@ public object FfiConverterTypeVerifiablePresentationData: FfiConverterRustBuffer
             FfiConverterTimestamp.read(buf),
             FfiConverterOptionalTimestamp.read(buf),
             FfiConverterSequenceString.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
@@ -7091,7 +7097,8 @@ public object FfiConverterTypeVerifiablePresentationData: FfiConverterRustBuffer
             FfiConverterString.allocationSize(value.`holder`) +
             FfiConverterTimestamp.allocationSize(value.`issuanceDate`) +
             FfiConverterOptionalTimestamp.allocationSize(value.`expirationDate`) +
-            FfiConverterSequenceString.allocationSize(value.`verifiableCredential`)
+            FfiConverterSequenceString.allocationSize(value.`verifiableCredential`) +
+            FfiConverterOptionalString.allocationSize(value.`jsonSerializedAdditionalData`)
     )
 
     override fun write(value: VerifiablePresentationData, buf: ByteBuffer) {
@@ -7102,6 +7109,7 @@ public object FfiConverterTypeVerifiablePresentationData: FfiConverterRustBuffer
             FfiConverterTimestamp.write(value.`issuanceDate`, buf)
             FfiConverterOptionalTimestamp.write(value.`expirationDate`, buf)
             FfiConverterSequenceString.write(value.`verifiableCredential`, buf)
+            FfiConverterOptionalString.write(value.`jsonSerializedAdditionalData`, buf)
     }
 }
 

--- a/bound/kt/src/test/kotlin/web5/sdk/vc/VerifiablePresentationTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/vc/VerifiablePresentationTest.kt
@@ -91,4 +91,43 @@ class VerifiablePresentationTest {
         assertEquals(vp.type, decodedVp.type)
         assertEquals(vp.verifiableCredential, decodedVp.verifiableCredential)
     }
+
+    @Test
+    fun test_create_verifiable_presentation_with_additional_properties() {
+        val holder = HOLDER_DID_URI
+        val verifiableCredential = listOf(VERIFIABLE_CREDENTIAL)
+
+        // Define additional properties to test
+        val additionalProperties = mapOf(
+            "customProperty1" to "customValue1",
+            "customProperty2" to 12345,
+            "customProperty3" to true
+        )
+
+        val options = VerifiablePresentationCreateOptions(
+            id = "urn:uuid:12345678-1234-5678-1234-567812345678",
+            context = listOf("https://www.w3.org/2018/credentials/v1"),
+            type = listOf("VerifiablePresentation"),
+            issuanceDate = Date(),
+            expirationDate = Date(System.currentTimeMillis() + 86400000), // 1 day later
+            additionalProperties = additionalProperties
+        )
+
+        val vp = VerifiablePresentation.create(holder, verifiableCredential, options)
+
+        // Assertions
+        assertEquals(holder, vp.holder)
+        assertEquals(options.id, vp.id)
+        assertEquals(options.context, vp.context)
+        assertEquals(options.type, vp.type)
+        assertEquals(verifiableCredential, vp.verifiableCredential)
+        assertNotNull(vp.issuanceDate)
+        assertNotNull(vp.expirationDate)
+        assertNotNull(vp.additionalProperties)
+
+        // Check that the additional properties match
+        assertEquals("customValue1", vp.additionalProperties?.get("customProperty1"))
+        assertEquals(12345, vp.additionalProperties?.get("customProperty2"))
+        assertEquals(true, vp.additionalProperties?.get("customProperty3"))
+    }
 }

--- a/bound/kt/src/test/kotlin/web5/sdk/vc/pex/PresentationDefinitionTest.kt
+++ b/bound/kt/src/test/kotlin/web5/sdk/vc/pex/PresentationDefinitionTest.kt
@@ -1,10 +1,10 @@
 package web5.sdk.vc.pex
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import web5.sdk.Json
+import web5.sdk.dids.methods.jwk.DidJwk
+import web5.sdk.vc.*
 
 class PresentationDefinitionTest {
 
@@ -62,5 +62,206 @@ class PresentationDefinitionTest {
     assertEquals("string", filter?.type)
     assertEquals("^[a-zA-Z]+$", filter?.pattern)
     assertNull(filter?.const)
+  }
+
+  @Test
+  fun `test select credentials`() {
+    // Define a mock InputDescriptor with constraints
+    val inputDescriptor = InputDescriptor(
+      id = "test_input",
+      name = "Test Input",
+      purpose = "For testing",
+      constraints = Constraints(
+        fields = listOf(
+          Field(
+            id = "field1",
+            name = "Field 1",
+            path = listOf("$.credentialSubject.id"),
+            purpose = "Test field",
+            filter = Filter(
+              type = "string",
+              pattern = "^did:jwk:.*$", // Matching pattern for DID JWK
+            ),
+            optional = false,
+            predicate = Optionality.Required
+          )
+        )
+      )
+    )
+
+    // Create a PresentationDefinition with the InputDescriptor
+    val presentationDefinition = PresentationDefinition(
+      id = "test_presentation",
+      name = "Test Presentation",
+      purpose = "For testing purposes",
+      inputDescriptors = listOf(inputDescriptor)
+    )
+
+    val vcJwt1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSkhXWEZKYTB4aU4zWnVZa3RtYlVoSVZrTndjREpPUW5kT1ZFSlFPWGRVWlc0dGRrWlJlV2hMYm5wM0luMCMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJpZCI6InVybjp1dWlkOjRjZjQ2Y2ZkLTAwMGQtNDJiZi1iZWYyLTEwOGFkYzNlMTBmZSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOmp3azpleUpoYkdjaU9pSkZaREkxTlRFNUlpd2lhM1I1SWpvaVQwdFFJaXdpWTNKMklqb2lSV1F5TlRVeE9TSXNJbmdpT2lKSFdYRkphMHhpTjNadVlrdG1iVWhJVmtOd2NESk9RbmRPVkVKUU9YZFVaVzR0ZGtaUmVXaExibnAzSW4wIiwiaXNzdWFuY2VEYXRlIjoiMjAyNC0wOS0xMFQxODowMTo0M1oiLCJleHBpcmF0aW9uRGF0ZSI6bnVsbCwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlpESTFOVEU1SWl3aWEzUjVJam9pVDB0UUlpd2lZM0oySWpvaVJXUXlOVFV4T1NJc0luZ2lPaUpIV1hGSmEweGlOM1p1WWt0bWJVaElWa053Y0RKT1FuZE9WRUpRT1hkVVpXNHRka1pSZVdoTGJucDNJbjAifX0sImlzcyI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSkhXWEZKYTB4aU4zWnVZa3RtYlVoSVZrTndjREpPUW5kT1ZFSlFPWGRVWlc0dGRrWlJlV2hMYm5wM0luMCIsImp0aSI6InVybjp1dWlkOjRjZjQ2Y2ZkLTAwMGQtNDJiZi1iZWYyLTEwOGFkYzNlMTBmZSIsInN1YiI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSkhXWEZKYTB4aU4zWnVZa3RtYlVoSVZrTndjREpPUW5kT1ZFSlFPWGRVWlc0dGRrWlJlV2hMYm5wM0luMCIsIm5iZiI6MTcyNTk5MTMwMywiaWF0IjoxNzI1OTkxMzAzfQ.mKMKH1XoqXPFVLREAXspb8JTrxSNDHCpJZF23uB7CSSzbKUtQBVk_wUIMPnOTCj6W5YcoF9Gsz4oWl_TlzfRDA"
+    val vcJwt2 = "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbVJSUm04eWJVbzFlbFJSVW5kbFRUZElTME5PYVROMlV6bGtORTFMWjJKNE1IWlBVRGh6U0VKSk9FVWlmUSMwIiwidHlwIjoiSldUIn0.eyJpc3MiOiJkaWQ6andrOmV5SnJkSGtpT2lKUFMxQWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SW1SUlJtOHliVW8xZWxSUlVuZGxUVGRJUzBOT2FUTjJVemxrTkUxTFoySjRNSFpQVURoelNFSkpPRVVpZlEiLCJqdGkiOiJ1cm46dmM6dXVpZDo2NDIzOTIxYy03NjEzLTQzYjAtOWVhMi1iOTA2MTNhMDMwNTciLCJuYmYiOjE3MTIyMzY3MjYsInN1YiI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbVJSUm04eWJVbzFlbFJSVW5kbFRUZElTME5PYVROMlV6bGtORTFMWjJKNE1IWlBVRGh6U0VKSk9FVWlmUSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJUQkRldmVsb3BlckNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOmp3azpleUpyZEhraU9pSlBTMUFpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpZUNJNkltUlJSbTh5YlVvMWVsUlJVbmRsVFRkSVMwTk9hVE4yVXpsa05FMUxaMko0TUhaUFVEaHpTRUpKT0VVaWZRIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6andrOmV5SnJkSGtpT2lKUFMxQWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SW1SUlJtOHliVW8xZWxSUlVuZGxUVGRJUzBOT2FUTjJVemxrTkUxTFoySjRNSFpQVURoelNFSkpPRVVpZlEiLCJ1c2VybmFtZSI6Im5pdHJvIn0sImlkIjoidXJuOnZjOnV1aWQ6NjQyMzkyMWMtNzYxMy00M2IwLTllYTItYjkwNjEzYTAzMDU3IiwiaXNzdWFuY2VEYXRlIjoiMjAyNC0wNC0wNFQxMzoxODo0NloifX0.AahszhMp2ZpKyr-Mtt_CtNGFxAfhxptUN88AdsANKkAQ824qblkeocIhGokWnGQY8-W59cm8Va9wYhmkVv9oAg"
+
+    val vcJwts = listOf(vcJwt1, vcJwt2)
+
+    // Test the selectCredentials function
+    val selectedCredentials = presentationDefinition.selectCredentials(vcJwts)
+
+    // Assert that only the valid JWT is selected
+    assertEquals(1, selectedCredentials.size)
+    assertTrue(selectedCredentials.contains(vcJwt1))
+  }
+
+  @Test
+  fun `test create presentation from credentials`() {
+    // Define a mock InputDescriptor with constraints
+    val inputDescriptor = InputDescriptor(
+      id = "test_input",
+      name = "Test Input",
+      purpose = "For testing",
+      constraints = Constraints(
+        fields = listOf(
+          Field(
+            id = "field1",
+            name = "Field 1",
+            path = listOf("$.credentialSubject.id"),
+            purpose = "Test field",
+            filter = Filter(
+              type = "string",
+              pattern = "^did:jwk:.*$", // Matching pattern for DID JWK
+            ),
+            optional = false,
+            predicate = Optionality.Required
+          )
+        )
+      )
+    )
+
+    // Create a PresentationDefinition with the InputDescriptor
+    val presentationDefinition = PresentationDefinition(
+      id = "test_presentation",
+      name = "Test Presentation",
+      purpose = "For testing purposes",
+      inputDescriptors = listOf(inputDescriptor)
+    )
+
+    val vcJwt1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSkhXWEZKYTB4aU4zWnVZa3RtYlVoSVZrTndjREpPUW5kT1ZFSlFPWGRVWlc0dGRrWlJlV2hMYm5wM0luMCMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJpZCI6InVybjp1dWlkOjRjZjQ2Y2ZkLTAwMGQtNDJiZi1iZWYyLTEwOGFkYzNlMTBmZSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOmp3azpleUpoYkdjaU9pSkZaREkxTlRFNUlpd2lhM1I1SWpvaVQwdFFJaXdpWTNKMklqb2lSV1F5TlRVeE9TSXNJbmdpT2lKSFdYRkphMHhpTjNadVlrdG1iVWhJVmtOd2NESk9RbmRPVkVKUU9YZFVaVzR0ZGtaUmVXaExibnAzSW4wIiwiaXNzdWFuY2VEYXRlIjoiMjAyNC0wOS0xMFQxODowMTo0M1oiLCJleHBpcmF0aW9uRGF0ZSI6bnVsbCwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlpESTFOVEU1SWl3aWEzUjVJam9pVDB0UUlpd2lZM0oySWpvaVJXUXlOVFV4T1NJc0luZ2lPaUpIV1hGSmEweGlOM1p1WWt0bWJVaElWa053Y0RKT1FuZE9WRUpRT1hkVVpXNHRka1pSZVdoTGJucDNJbjAifX0sImlzcyI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSkhXWEZKYTB4aU4zWnVZa3RtYlVoSVZrTndjREpPUW5kT1ZFSlFPWGRVWlc0dGRrWlJlV2hMYm5wM0luMCIsImp0aSI6InVybjp1dWlkOjRjZjQ2Y2ZkLTAwMGQtNDJiZi1iZWYyLTEwOGFkYzNlMTBmZSIsInN1YiI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGWkRJMU5URTVJaXdpYTNSNUlqb2lUMHRRSWl3aVkzSjJJam9pUldReU5UVXhPU0lzSW5naU9pSkhXWEZKYTB4aU4zWnVZa3RtYlVoSVZrTndjREpPUW5kT1ZFSlFPWGRVWlc0dGRrWlJlV2hMYm5wM0luMCIsIm5iZiI6MTcyNTk5MTMwMywiaWF0IjoxNzI1OTkxMzAzfQ.mKMKH1XoqXPFVLREAXspb8JTrxSNDHCpJZF23uB7CSSzbKUtQBVk_wUIMPnOTCj6W5YcoF9Gsz4oWl_TlzfRDA"
+    val vcJwt2 = "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbVJSUm04eWJVbzFlbFJSVW5kbFRUZElTME5PYVROMlV6bGtORTFMWjJKNE1IWlBVRGh6U0VKSk9FVWlmUSMwIiwidHlwIjoiSldUIn0.eyJpc3MiOiJkaWQ6andrOmV5SnJkSGtpT2lKUFMxQWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SW1SUlJtOHliVW8xZWxSUlVuZGxUVGRJUzBOT2FUTjJVemxrTkUxTFoySjRNSFpQVURoelNFSkpPRVVpZlEiLCJqdGkiOiJ1cm46dmM6dXVpZDo2NDIzOTIxYy03NjEzLTQzYjAtOWVhMi1iOTA2MTNhMDMwNTciLCJuYmYiOjE3MTIyMzY3MjYsInN1YiI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbVJSUm04eWJVbzFlbFJSVW5kbFRUZElTME5PYVROMlV6bGtORTFMWjJKNE1IWlBVRGh6U0VKSk9FVWlmUSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJUQkRldmVsb3BlckNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOmp3azpleUpyZEhraU9pSlBTMUFpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpZUNJNkltUlJSbTh5YlVvMWVsUlJVbmRsVFRkSVMwTk9hVE4yVXpsa05FMUxaMko0TUhaUFVEaHpTRUpKT0VVaWZRIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6andrOmV5SnJkSGtpT2lKUFMxQWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SW1SUlJtOHliVW8xZWxSUlVuZGxUVGRJUzBOT2FUTjJVemxrTkUxTFoySjRNSFpQVURoelNFSkpPRVVpZlEiLCJ1c2VybmFtZSI6Im5pdHJvIn0sImlkIjoidXJuOnZjOnV1aWQ6NjQyMzkyMWMtNzYxMy00M2IwLTllYTItYjkwNjEzYTAzMDU3IiwiaXNzdWFuY2VEYXRlIjoiMjAyNC0wNC0wNFQxMzoxODo0NloifX0.AahszhMp2ZpKyr-Mtt_CtNGFxAfhxptUN88AdsANKkAQ824qblkeocIhGokWnGQY8-W59cm8Va9wYhmkVv9oAg"
+
+    val vcJwts = listOf(vcJwt1, vcJwt2)
+
+    // Test the createPresentationFromCredentials function
+    val presentationResult = presentationDefinition.createPresentationFromCredentials(vcJwts)
+
+    // Validate the results
+    assertNotNull(presentationResult, "PresentationResult should not be null")
+
+    // Validate that a PresentationSubmission was created
+    val submission = presentationResult.presentationSubmission
+    assertNotNull(submission, "PresentationSubmission should not be null")
+    assertEquals("test_presentation", submission.definitionId)
+
+    // Validate the descriptor map
+    val descriptorMap = submission.descriptorMap
+    assertEquals(1, descriptorMap.size, "There should be one descriptor in the map")
+    assertEquals("test_input", descriptorMap[0].id)
+    assertEquals("jwt_vc", descriptorMap[0].format)
+    assertEquals("$.verifiableCredential[0]", descriptorMap[0].path)
+
+    // Validate the matched VCs
+    val matchedVcJwts = presentationResult.matchedVcJwts
+    assertEquals(1, matchedVcJwts.size, "Only one VC should have been matched")
+    assertTrue(matchedVcJwts.contains(vcJwt1))
+  }
+
+  @Test
+  fun `test full presentation exchange flow`() {
+    // Step 1: Create an issuer (typically the entity that issued the credential)
+    val issuer = DidJwk.create()
+    val issuerUri = issuer.did.uri
+
+    // Step 2: Define a Presentation Definition (PD) that specifies the required input descriptors
+    val inputDescriptor = InputDescriptor(
+      id = "test_input",
+      name = "Test Input",
+      purpose = "Testing Input",
+      constraints = Constraints(
+        fields = listOf(
+          Field(
+            id = "field1",
+            name = "Field 1",
+            path = listOf("$.credentialSubject.id"),
+            purpose = "Must match DID JWK pattern",
+            filter = Filter(
+              type = "string",
+              pattern = "^did:jwk:.*$" // Matching pattern for DID JWK
+            ),
+            optional = false,
+            predicate = Optionality.Required
+          )
+        )
+      )
+    )
+
+    // Create a Presentation Definition with the InputDescriptor
+    val presentationDefinition = PresentationDefinition(
+      id = "test_presentation_definition",
+      name = "Test Presentation Definition",
+      purpose = "Testing Presentation Exchange",
+      inputDescriptors = listOf(inputDescriptor)
+    )
+
+    // Step 3: Create a Verifiable Credential (VC) with a credential subject matching the PD criteria
+    val vc = VerifiableCredential.create(
+      Issuer.StringIssuer(issuerUri),
+      CredentialSubject(issuerUri)
+    )
+
+    val vcJwt = vc.sign(issuer)
+
+    // Step 4: Select the credentials that match the PD's input descriptors
+    val vcJwts = listOf(vcJwt)
+    val presentationResult = presentationDefinition.createPresentationFromCredentials(vcJwts)
+
+    // Step 5: Create the Verifiable Presentation (VP) with the selected credentials
+    val holder = DidJwk.create() // The holder of the Verifiable Presentation
+    val holderUri = holder.did.uri
+
+    // Additional data includes the presentation submission, which links the presentation to the PD
+    val additionalData = mapOf(
+      "presentation_submission" to presentationResult.presentationSubmission
+    )
+
+    val vpCreateOptions = VerifiablePresentationCreateOptions(
+      additionalProperties = additionalData
+    )
+
+    // Generate the Verifiable Presentation
+    val vp = VerifiablePresentation.create(
+      holderUri,
+      presentationResult.matchedVcJwts,
+      vpCreateOptions
+    )
+
+    // Step 6: Sign the VP to generate a JWT format
+    val signedVpJwt = vp.sign(holder)
+
+    // Step 7: Decode and verify the signed VP to ensure correctness
+    val decodedVp = VerifiablePresentation.fromVpJwt(signedVpJwt, true)
+
+    // Step 8: Verify the holder matches the expected holder
+    assertEquals(holderUri, decodedVp.holder)
+
+    // Step 9: Verify that the correct Verifiable Credential was included in the presentation
+    assertEquals(1, decodedVp.verifiableCredential.size)
+    assertEquals(vcJwt, decodedVp.verifiableCredential[0])
+
+    // Step 10: Retrieve the presentation_submission from the decoded VP's additional data
+    val decodedPresentationSubmissionMap = decodedVp.additionalProperties?.get("presentation_submission") as? Map<*, *>
+
+    // Step 11: Convert the map back to PresentationSubmission
+    val jsonPresentationSubmission = Json.jsonMapper.writeValueAsString(decodedPresentationSubmissionMap)
+    val decodedPresentationSubmission = Json.jsonMapper.readValue(jsonPresentationSubmission, PresentationSubmission::class.java)
+
+    // Step 12: Verify that the presentation_submission in additional_data matches the original one
+    assertEquals(presentationResult.presentationSubmission, decodedPresentationSubmission)
   }
 }

--- a/crates/web5/src/credentials/mod.rs
+++ b/crates/web5/src/credentials/mod.rs
@@ -15,7 +15,6 @@ pub use status_list_credential::{
 };
 mod verifiable_credential_1_1;
 mod verifiable_presentation_1_1;
-mod presentation_submission;
 
 pub use verifiable_credential_1_1::CredentialStatus;
 pub use verifiable_credential_1_1::VerifiableCredential;

--- a/crates/web5/src/credentials/mod.rs
+++ b/crates/web5/src/credentials/mod.rs
@@ -15,6 +15,7 @@ pub use status_list_credential::{
 };
 mod verifiable_credential_1_1;
 mod verifiable_presentation_1_1;
+mod presentation_submission;
 
 pub use verifiable_credential_1_1::CredentialStatus;
 pub use verifiable_credential_1_1::VerifiableCredential;

--- a/crates/web5/src/credentials/presentation_definition.rs
+++ b/crates/web5/src/credentials/presentation_definition.rs
@@ -29,7 +29,10 @@ pub struct PresentationDefinition {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub purpose: Option<String>,
+
+    #[serde(rename = "inputDescriptors")]
     pub input_descriptors: Vec<InputDescriptor>,
+    #[serde(rename = "submissionRequirements")]
     pub submission_requirements: Option<Vec<SubmissionRequirement>>,
 }
 
@@ -96,7 +99,7 @@ pub struct SubmissionRequirement {
     pub rule: SubmissionRequirementRule,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "fromNested")]
     pub from_nested: Option<Vec<SubmissionRequirement>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -123,10 +126,10 @@ pub enum SubmissionRequirementRule {
 pub struct PresentationSubmission {
     pub id: String,
 
-    #[serde(rename = "definition_id")]
+    #[serde(rename = "definitionId")]
     pub definition_id: String,
 
-    #[serde(rename = "descriptor_map")]
+    #[serde(rename = "descriptorMap")]
     pub descriptor_map: Vec<InputDescriptorMapping>,
 }
 
@@ -137,13 +140,15 @@ pub struct InputDescriptorMapping {
     pub format: String,
     pub path: String,
 
-    #[serde(rename = "path_nested")]
+    #[serde(rename = "pathNested")]
     pub path_nested: Option<Box<InputDescriptorMapping>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PresentationResult {
+    #[serde(rename = "presentationSubmission")]
     pub presentation_submission: PresentationSubmission,
+    #[serde(rename = "matchedVcJwts")]
     pub matched_vc_jwts: Vec<String>,
 }
 

--- a/crates/web5/src/credentials/presentation_definition.rs
+++ b/crates/web5/src/credentials/presentation_definition.rs
@@ -8,13 +8,14 @@ use jsonschema::JSONSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, to_value, Map, Value};
 use uuid::Uuid;
-
 use crate::credentials::verifiable_credential_1_1::VerifiableCredential;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum PexError {
     #[error("Failed to parse JSON: {0}")]
     JsonError(String),
+    #[error("Invalid PEX state: {0}")]
+    IllegalState(String),
 }
 
 type Result<T> = std::result::Result<T, PexError>;
@@ -29,6 +30,7 @@ pub struct PresentationDefinition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub purpose: Option<String>,
     pub input_descriptors: Vec<InputDescriptor>,
+    pub submission_requirements: Option<Vec<SubmissionRequirement>>,
 }
 
 /// Represents a DIF Input Descriptor defined [here](https://identity.foundation/presentation-exchange/#input-descriptor).
@@ -89,11 +91,71 @@ pub struct Filter {
     pub contains: Option<Box<Filter>>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct SubmissionRequirement {
+    pub rule: SubmissionRequirementRule,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_nested: Option<Vec<SubmissionRequirement>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum SubmissionRequirementRule {
+    All,
+    Pick,
+}
+
+/// Represents a presentation submission object.
+///
+/// See [Presentation Submission](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PresentationSubmission {
+    pub id: String,
+
+    #[serde(rename = "definition_id")]
+    pub definition_id: String,
+
+    #[serde(rename = "descriptor_map")]
+    pub descriptor_map: Vec<InputDescriptorMapping>,
+}
+
+/// Represents descriptor map for a presentation submission.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct InputDescriptorMapping {
+    pub id: String,
+    pub format: String,
+    pub path: String,
+
+    #[serde(rename = "path_nested")]
+    pub path_nested: Option<Box<InputDescriptorMapping>>,
+}
+
 fn generate_token() -> String {
     Uuid::new_v4().to_string()
 }
 
 impl PresentationDefinition {
+
+    /// Selects Verifiable Credentials (VCs) that match the input descriptors of the presentation definition.
+    ///
+    /// # Arguments
+    ///
+    /// * `vc_jwts` - A reference to a vector of VC JWTs to validate.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of VCs that fulfill the input descriptors. If no VCs match, returns an empty vector.
     pub fn select_credentials(&self, vc_jwts: &Vec<String>) -> Result<Vec<String>> {
         let mut matches: HashSet<String> = HashSet::new();
 
@@ -106,6 +168,92 @@ impl PresentationDefinition {
         }
 
         Ok(matches.into_iter().collect())
+    }
+
+    /// Creates a Presentation Submission in which the list of Verifiable Credentials JWTs (VCs) fulfills the given Presentation Definition.
+    ///
+    /// # Arguments
+    ///
+    /// * `vc_jwts` - Iterable of VCs in JWT format to validate.
+    /// * `presentation_definition` - The Presentation Definition V2 object against which VCs are validated.
+    ///
+    /// # Returns
+    ///
+    /// A `PresentationSubmission` object.
+    /// A `Vec<String>` which contains the chosen vc_jwts
+    pub fn create_presentation_from_credentials(
+        &self,
+        vc_jwts: &Vec<String>,
+    ) -> Result<(PresentationSubmission, Vec<String>)> {
+        // Check if there are submission requirements (not supported in this implementation)
+        if self.submission_requirements.is_some() {
+            return Err(PexError::IllegalState(
+                "Submission requirements are not supported".to_string(),
+            ));
+        }
+
+        // Select the appropriate credentials that match the presentation definition
+        let selected_credentials = self.select_credentials(vc_jwts)?;
+
+        if selected_credentials.is_empty() {
+            return Err(PexError::IllegalState(
+                "No VCs correspond to any input descriptor".to_string(),
+            ));
+        }
+
+        let mut descriptor_map = Vec::new();
+        let mut used_vc_jwts = Vec::new();
+
+        for input_descriptor in &self.input_descriptors {
+            let matching_vcs: Vec<&String> = selected_credentials
+                .iter()
+                .filter(|vc_jwt| {
+                    input_descriptor
+                        .select_credentials(&vec![vc_jwt.to_string()])
+                        .map(|result| !result.is_empty())
+                        .unwrap_or(false)
+                })
+                .collect();
+
+            if matching_vcs.is_empty() {
+                return Err(PexError::IllegalState(format!(
+                    "No VC corresponds to input descriptor {}",
+                    input_descriptor.id
+                )));
+            }
+
+            // For simplicity, we're using the first matching VC for each input descriptor
+            let vc_jwt = matching_vcs[0];
+            let vc_index = vc_jwts
+                .iter()
+                .position(|jwt| jwt == vc_jwt)
+                .ok_or_else(|| PexError::IllegalState("VC index not found".to_string()))?;
+
+            descriptor_map.push(InputDescriptorMapping {
+                id: input_descriptor.id.clone(),
+                format: "jwt_vc".to_string(),
+                path: format!("$.verifiableCredential[{}]", vc_index),
+                path_nested: None,
+            });
+
+            // Add the selected vc_jwt to the used_vc_jwts list
+            used_vc_jwts.push(vc_jwt.to_string());
+        }
+
+        if descriptor_map.len() < self.input_descriptors.len() {
+            return Err(PexError::IllegalState(
+                "The number of input descriptors matched is less than required".to_string(),
+            ));
+        }
+
+        let presentation_submission = PresentationSubmission {
+            id: Uuid::new_v4().to_string(),
+            definition_id: self.id.clone(),
+            descriptor_map,
+        };
+
+        // Return both the presentation submission and the list of used vc_jwts
+        Ok((presentation_submission, used_vc_jwts))
     }
 }
 
@@ -236,5 +384,325 @@ impl JsonSchemaBuilder {
             "properties": self.properties,
             "required": self.required,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use super::*;
+    use serde_json::json;
+    use crate::credentials::{CredentialSubject, Issuer, VerifiablePresentation, VerifiablePresentationCreateOptions};
+    use crate::dids::methods::did_jwk::DidJwk;
+    use crate::json::{JsonObject, JsonValue};
+
+    #[test]
+    fn test_create_presentation_from_credentials() {
+        let issuer = DidJwk::create(None).unwrap();
+        let issuer_uri = issuer.clone().did.uri;
+
+        let presentation_definition = PresentationDefinition {
+            id: "test_pd_id".to_string(),
+            name: Some("Test Presentation Definition".to_string()),
+            purpose: Some("Testing".to_string()),
+            input_descriptors: vec![
+                InputDescriptor {
+                    id: "test_input_1".to_string(),
+                    name: Some("Test Input 1".to_string()),
+                    purpose: Some("Testing Input 1".to_string()),
+                    constraints: Constraints {
+                        fields: vec![
+                            Field {
+                                path: vec!["$.credentialSubject.id".to_string()],
+                                filter: Some(Filter {
+                                    r#type: Some("string".to_string()),
+                                    pattern: Some("^did:jwk:.*$".to_string()),
+                                    const_value: None,
+                                    contains: None,
+                                }),
+                                id: None,
+                                name: None,
+                                purpose: None,
+                                optional: None,
+                                predicate: None,
+                            }
+                        ],
+                    },
+                }
+            ],
+            submission_requirements: None,
+        };
+
+        let vc_1 = VerifiableCredential::create(
+            Issuer::from(issuer_uri.clone()),
+            CredentialSubject::from(issuer_uri.clone()),
+            Default::default(),
+        ).unwrap();
+
+        let signed_vcjwt_1 = vc_1.sign(&issuer.clone(), None).unwrap();
+
+        let vc_jwts = vec![
+            signed_vcjwt_1
+        ];
+
+        let result = presentation_definition.create_presentation_from_credentials(&vc_jwts);
+
+        assert!(result.is_ok(), "Failed to create presentation submission");
+
+        let presentation_submission = result.unwrap();
+
+        assert_eq!(presentation_submission.0.definition_id, "test_pd_id");
+        assert_eq!(presentation_submission.0.descriptor_map.len(), 1);
+        assert_eq!(presentation_submission.0.descriptor_map[0].id, "test_input_1");
+        assert_eq!(presentation_submission.0.descriptor_map[0].format, "jwt_vc");
+        assert_eq!(presentation_submission.0.descriptor_map[0].path, "$.verifiableCredential[0]");
+    }
+
+    #[test]
+    fn test_presentation_exchange_full_flow() {
+        let issuer = DidJwk::create(None).unwrap();
+        let issuer_uri = issuer.clone().did.uri;
+
+        let presentation_definition = PresentationDefinition {
+            id: "test_pd_id".to_string(),
+            name: Some("Test Presentation Definition".to_string()),
+            purpose: Some("Testing".to_string()),
+            input_descriptors: vec![InputDescriptor {
+                id: "test_input_1".to_string(),
+                name: Some("Test Input 1".to_string()),
+                purpose: Some("Testing Input 1".to_string()),
+                constraints: Constraints {
+                    fields: vec![Field {
+                        path: vec!["$.credentialSubject.id".to_string()],
+                        filter: Some(Filter {
+                            r#type: Some("string".to_string()),
+                            pattern: Some("^did:jwk:.*$".to_string()),
+                            const_value: None,
+                            contains: None,
+                        }),
+                        id: None,
+                        name: None,
+                        purpose: None,
+                        optional: None,
+                        predicate: None,
+                    }],
+                },
+            }],
+            submission_requirements: None,
+        };
+
+        let vc_1 = VerifiableCredential::create(
+            Issuer::from(issuer_uri.clone()),
+            CredentialSubject::from(issuer_uri.clone()),
+            Default::default(),
+        )
+            .unwrap();
+
+        let signed_vcjwt_1 = vc_1.sign(&issuer.clone(), None).unwrap();
+
+        let vc_jwts = vec![signed_vcjwt_1.clone()];
+
+        let (presentation_submission, selected_vcs) = presentation_definition
+            .create_presentation_from_credentials(&vc_jwts)
+            .unwrap();
+
+        let holder = DidJwk::create(None).unwrap();
+        let holder_uri = holder.clone().did.uri;
+
+        let mut additional_data = HashMap::new();
+        additional_data.insert(
+            "presentation_submission".to_string(),
+            json!(presentation_submission),
+        );
+
+        let vp_create_options = VerifiablePresentationCreateOptions {
+            additional_data: Some(additional_data),
+            ..Default::default()
+        };
+
+        let vp = VerifiablePresentation::create(holder_uri.clone(), selected_vcs, Some(vp_create_options))
+            .expect("Failed to create Verifiable Presentation");
+
+        let vp_jwt = vp.sign(&holder.clone(), None).unwrap();
+
+        let decoded_vp = VerifiablePresentation::from_vp_jwt(&vp_jwt, true)
+            .expect("Failed to decode Verifiable Presentation JWT");
+
+        // Check that the holder matches
+        assert_eq!(decoded_vp.holder, holder_uri);
+
+        // Check that the verifiable credential matches
+        assert_eq!(decoded_vp.verifiable_credential.len(), 1);
+        assert_eq!(decoded_vp.verifiable_credential[0], signed_vcjwt_1);
+
+        // Retrieve the presentation_submission from decoded_vp.additional_data
+        let decoded_presentation_submission = decoded_vp
+            .additional_data
+            .as_ref()
+            .and_then(|data| data.get("presentation_submission"));
+
+        // Check if the decoded presentation_submission is equal to the original one
+        assert_eq!(
+            decoded_presentation_submission,
+            Some(&json!(presentation_submission)),
+            "The presentation_submission in additional_data does not match the expected value"
+        );
+    }
+
+    #[test]
+    fn test_presentation_exchange_with_multiple_vcs() {
+        let issuer = DidJwk::create(None).unwrap();
+        let issuer_uri = issuer.clone().did.uri;
+
+        // Define a Presentation Definition with multiple input descriptors
+        let presentation_definition = PresentationDefinition {
+            id: "test_pd_id".to_string(),
+            name: Some("Test Presentation Definition".to_string()),
+            purpose: Some("Testing".to_string()),
+            input_descriptors: vec![
+                InputDescriptor {
+                    id: "test_input_1".to_string(),
+                    name: Some("Test Input 1".to_string()),
+                    purpose: Some("Testing Input 1".to_string()),
+                    constraints: Constraints {
+                        fields: vec![Field {
+                            path: vec!["$.credentialSubject.id".to_string()],
+                            filter: Some(Filter {
+                                r#type: Some("string".to_string()),
+                                pattern: Some("^did:jwk:.*$".to_string()),
+                                const_value: None,
+                                contains: None,
+                            }),
+                            id: None,
+                            name: None,
+                            purpose: None,
+                            optional: None,
+                            predicate: None,
+                        }],
+                    },
+                },
+                InputDescriptor {
+                    id: "test_input_2".to_string(),
+                    name: Some("Test Input 2".to_string()),
+                    purpose: Some("Testing Input 2".to_string()),
+                    constraints: Constraints {
+                        fields: vec![Field {
+                            path: vec!["$.credentialSubject.role".to_string()],
+                            filter: Some(Filter {
+                                r#type: Some("string".to_string()),
+                                pattern: Some("^admin$".to_string()),
+                                const_value: None,
+                                contains: None,
+                            }),
+                            id: None,
+                            name: None,
+                            purpose: None,
+                            optional: None,
+                            predicate: None,
+                        }],
+                    },
+                },
+            ],
+            submission_requirements: None,
+        };
+
+        // Create 3 Verifiable Credentials, where one doesn't match any input descriptor
+        let vc_1 = VerifiableCredential::create(
+            Issuer::from(issuer_uri.clone()),
+            CredentialSubject {
+                id: issuer_uri.clone(),
+                additional_properties: None, // No additional properties for this one
+            },
+            Default::default(),
+        )
+            .unwrap();
+
+        // For vc_2, we add the "role" property to match the second input descriptor
+        let vc_2_credential_subject = CredentialSubject {
+            id: format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            additional_properties: Some(JsonObject {
+                properties: [("role".to_string(), JsonValue::String("admin".to_string()))]
+                    .into_iter()
+                    .collect(),
+            }),
+        };
+
+        let vc_2 = VerifiableCredential::create(
+            Issuer::from(issuer_uri.clone()),
+            vc_2_credential_subject,
+            Default::default(),
+        ).unwrap();
+
+        // vc_3 won't match either input descriptor
+        let vc_3 = VerifiableCredential::create(
+            Issuer::from(issuer_uri.clone()),
+            CredentialSubject {
+                id: format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+                additional_properties: None, // No matching role
+            },
+            Default::default(),
+        ).unwrap();
+
+        // Sign all three VCs
+        let signed_vcjwt_1 = vc_1.sign(&issuer.clone(), None).unwrap();
+        let signed_vcjwt_2 = vc_2.sign(&issuer.clone(), None).unwrap();
+        let signed_vcjwt_3 = vc_3.sign(&issuer.clone(), None).unwrap();
+
+        let vc_jwts = vec![
+            signed_vcjwt_1.clone(),
+            signed_vcjwt_2.clone(),
+            signed_vcjwt_3.clone(), // This VC should not be included in the submission
+        ];
+
+        // Unwrap the result of `create_presentation_from_credentials`
+        let (presentation_submission, selected_vcs) = presentation_definition
+            .create_presentation_from_credentials(&vc_jwts)
+            .unwrap();
+
+        let holder = DidJwk::create(None).unwrap();
+        let holder_uri = holder.clone().did.uri;
+
+        let mut additional_data = HashMap::new();
+        additional_data.insert(
+            "presentation_submission".to_string(),
+            json!(presentation_submission),
+        );
+
+        let vp_create_options = VerifiablePresentationCreateOptions {
+            additional_data: Some(additional_data),
+            ..Default::default()
+        };
+
+        // Use the `selected_vcs` directly
+        let vp = VerifiablePresentation::create(holder_uri.clone(), selected_vcs, Some(vp_create_options))
+            .expect("Failed to create Verifiable Presentation");
+
+        let vp_jwt = vp.sign(&holder.clone(), None).unwrap();
+
+        // Decode the Verifiable Presentation JWT
+        let decoded_vp = VerifiablePresentation::from_vp_jwt(&vp_jwt, true)
+            .expect("Failed to decode Verifiable Presentation JWT");
+
+        // Check that the holder matches
+        assert_eq!(decoded_vp.holder, holder_uri);
+
+        // Check that the verifiable credentials match the selected ones (should only include vc_1 and vc_2)
+        assert_eq!(decoded_vp.verifiable_credential.len(), 2);
+        assert!(decoded_vp.verifiable_credential.contains(&signed_vcjwt_1));
+        assert!(decoded_vp.verifiable_credential.contains(&signed_vcjwt_2));
+        assert!(!decoded_vp.verifiable_credential.contains(&signed_vcjwt_3)); // vc_3 should not be included
+
+        // Retrieve the presentation_submission from decoded_vp.additional_data
+        let decoded_presentation_submission = decoded_vp
+            .additional_data
+            .as_ref()
+            .and_then(|data| data.get("presentation_submission"));
+
+        // Check if the decoded presentation_submission is equal to the original one
+        assert_eq!(
+            decoded_presentation_submission,
+            Some(&json!(presentation_submission)),
+            "The presentation_submission in additional_data does not match the expected value"
+        );
     }
 }

--- a/crates/web5/src/credentials/verifiable_presentation_1_1.rs
+++ b/crates/web5/src/credentials/verifiable_presentation_1_1.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use crate::credentials::josekit::{JoseSigner, JoseVerifier, JoseVerifierAlwaysTrue};
 use crate::credentials::verifiable_credential_1_1::VerifiableCredential;
 use crate::credentials::VerificationError;
@@ -18,6 +19,7 @@ use josekit::jwt::JwtPayload;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::SystemTime;
+use serde_json::Value;
 use uuid::Uuid;
 
 pub const BASE_PRESENTATION_CONTEXT: &str = "https://www.w3.org/2018/credentials/v1";
@@ -45,6 +47,8 @@ pub struct VerifiablePresentation {
     pub expiration_date: Option<SystemTime>,
     #[serde(rename = "verifiableCredential")]
     pub verifiable_credential: Vec<String>,
+    #[serde(flatten)]
+    pub additional_data: Option<HashMap<String, Value>>,
 }
 
 #[derive(Default, Clone)]
@@ -54,6 +58,7 @@ pub struct VerifiablePresentationCreateOptions {
     pub r#type: Option<Vec<String>>,
     pub issuance_date: Option<SystemTime>,
     pub expiration_date: Option<SystemTime>,
+    pub additional_data: Option<HashMap<String, Value>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -80,6 +85,8 @@ pub struct JwtPayloadVerifiablePresentation {
     pub expiration_date: Option<SystemTime>,
     #[serde(rename = "verifiableCredential", skip_serializing_if = "Vec::is_empty")]
     pub verifiable_credential: Vec<String>,
+    #[serde(flatten)]
+    pub additional_data: Option<HashMap<String, Value>>,
 }
 
 impl VerifiablePresentation {
@@ -115,6 +122,7 @@ impl VerifiablePresentation {
             issuance_date: options.issuance_date.unwrap_or_else(SystemTime::now),
             expiration_date: options.expiration_date,
             verifiable_credential: vc_jwts,
+            additional_data: options.additional_data,
         };
 
         Ok(verifiable_presentation)
@@ -153,6 +161,7 @@ pub fn sign_presentation_with_signer(
         verifiable_credential: vp.verifiable_credential.clone(),
         issuance_date: Some(vp.issuance_date),
         expiration_date: vp.expiration_date,
+        additional_data: vp.additional_data.clone()
     };
 
     payload
@@ -318,6 +327,7 @@ pub fn decode_vp_jwt(vp_jwt: &str, verify_signature: bool) -> Result<VerifiableP
         issuance_date: nbf,
         expiration_date: exp,
         verifiable_credential: vp_payload.verifiable_credential,
+        additional_data: vp_payload.additional_data
     };
 
     Ok(verifiable_presentation)

--- a/crates/web5/src/credentials/verifiable_presentation_1_1.rs
+++ b/crates/web5/src/credentials/verifiable_presentation_1_1.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use crate::credentials::josekit::{JoseSigner, JoseVerifier, JoseVerifierAlwaysTrue};
 use crate::credentials::verifiable_credential_1_1::VerifiableCredential;
 use crate::credentials::VerificationError;
@@ -17,9 +16,10 @@ use crate::rfc3339::{
 use josekit::jws::JwsHeader;
 use josekit::jwt::JwtPayload;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
-use serde_json::Value;
 use uuid::Uuid;
 
 pub const BASE_PRESENTATION_CONTEXT: &str = "https://www.w3.org/2018/credentials/v1";
@@ -161,7 +161,7 @@ pub fn sign_presentation_with_signer(
         verifiable_credential: vp.verifiable_credential.clone(),
         issuance_date: Some(vp.issuance_date),
         expiration_date: vp.expiration_date,
-        additional_data: vp.additional_data.clone()
+        additional_data: vp.additional_data.clone(),
     };
 
     payload
@@ -327,7 +327,7 @@ pub fn decode_vp_jwt(vp_jwt: &str, verify_signature: bool) -> Result<VerifiableP
         issuance_date: nbf,
         expiration_date: exp,
         verifiable_credential: vp_payload.verifiable_credential,
-        additional_data: vp_payload.additional_data
+        additional_data: vp_payload.additional_data,
     };
 
     Ok(verifiable_presentation)

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -198,7 +198,7 @@ CLASS PresentationDefinition
   PUBLIC DATA input_descriptors: []InputDescriptor
   
   METHOD select_credentials(vc_jwts: []string): []string
-  METHOD create_presentation_from_credentials(vc_jwts: []string): (PresentationSubmission, []string)
+  METHOD create_presentation_from_credentials(vc_jwts: []string): PresentationResult
 ```
 
 ### `InputDescriptor` 
@@ -247,6 +247,14 @@ CLASS Filter
   PUBLIC DATA pattern: string?
   PUBLIC DATA const_value: string?
   PUBLIC DATA contains: Filter?
+```
+
+### `PresentationResult`
+
+```pseudocode!
+CLASS PresentationResult
+  PUBLIC DATA presentation_submission: PresentationSubmission
+  PUBLIC DATA matched_vc_jwts: []string
 ```
 
 ### `PresentationSubmission`

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -166,6 +166,7 @@ CLASS VerifiablePresentation
   PUBLIC DATA issuance_date: datetime
   PUBLIC DATA expiration_date: datetime?
   PUBLIC DATA verifiable_credential: []string
+  PUBLIC DATA additional_data: Map<string, string>?
 
   CONSTRUCTOR create(holder: string, vc_jwts: []string, options: VerifiablePresentationCreateOptions?)
   CONSTRUCTOR from_vp_jwt(vp_jwt: string, verify: bool)
@@ -182,6 +183,7 @@ CLASS VerifiablePresentationCreateOptions
   PUBLIC DATA type: []string?
   PUBLIC DATA issuance_date: datetime?
   PUBLIC DATA expiration_date: datetime?
+  PUBLIC DATA additional_data: Map<string, string>?
 ```
 
 ## Presentation Exchange (PEX)
@@ -196,6 +198,7 @@ CLASS PresentationDefinition
   PUBLIC DATA input_descriptors: []InputDescriptor
   
   METHOD select_credentials(vc_jwts: []string): []string
+  METHOD create_presentation_from_credentials(vc_jwts: []string): (PresentationSubmission, []string)
 ```
 
 ### `InputDescriptor` 
@@ -246,6 +249,46 @@ CLASS Filter
   PUBLIC DATA contains: Filter?
 ```
 
+### `PresentationSubmission`
+
+```pseudocode!
+CLASS PresentationSubmission
+  PUBLIC DATA id: string
+  PUBLIC DATA definition_id: string
+  PUBLIC DATA descriptor_map: []InputDescriptorMapping
+```
+
+### `InputDescriptorMapping`
+
+```pseudocode!
+CLASS InputDescriptorMapping
+  PUBLIC DATA id: string
+  PUBLIC DATA format: string
+  PUBLIC DATA path: string
+  PUBLIC DATA path_nested: InputDescriptorMapping?
+```
+
+### `SubmissionRequirement`
+
+```pseudocode!
+CLASS SubmissionRequirement
+  PUBLIC DATA rule: SubmissionRequirementRule
+  PUBLIC DATA from: string?
+  PUBLIC DATA from_nested: []SubmissionRequirement?
+  PUBLIC DATA name: string?
+  PUBLIC DATA purpose: string?
+  PUBLIC DATA count: uint32?
+  PUBLIC DATA min: uint32?
+  PUBLIC DATA max: uint32?
+```
+
+### `SubmissionRequirementRule`
+
+```pseudocode!
+ENUM SubmissionRequirementRule
+  All
+  Pick
+```
 # Crypto
 
 ## `Jwk`

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -194,6 +194,7 @@ CLASS PresentationDefinition
   PUBLIC DATA name: string?
   PUBLIC DATA purpose: string?
   PUBLIC DATA input_descriptors: []InputDescriptor
+  
   METHOD select_credentials(vc_jwts: []string): []string
 ```
 


### PR DESCRIPTION
Added create_presentation_from_credentials to our `PresentationDefinition` object

```pseudocode!
CLASS PresentationDefinition
  PUBLIC DATA id: string
  PUBLIC DATA name: string?
  PUBLIC DATA purpose: string?
  PUBLIC DATA input_descriptors: []InputDescriptor
  
  METHOD select_credentials(vc_jwts: []string): []string
  METHOD create_presentation_from_credentials(vc_jwts: []string): PresentationResult
```

Here is a full flow someone would have to do to get a presentation submission and wrap it in a verifiable presentation:
```rust
/// This test demonstrates the full flow of a Presentation Exchange using a Verifiable Credential (VC) and a Presentation Definition (PD).
/// It covers the following steps:
///
/// 1. Creating an issuer and defining a Presentation Definition (PD) that outlines the criteria for acceptable VCs.
/// 2. Creating a Verifiable Credential (VC) that matches the requirements specified in the PD.
/// 3. Signing the VC to generate a Verifiable Credential in JWT format.
/// 4. Selecting credentials that fulfill the PD's input descriptors using `create_presentation_from_credentials`.
/// 5. Creating a Verifiable Presentation (VP) using the selected credentials.
/// 6. Signing the VP to generate a Verifiable Presentation in JWT format.
/// 7. Decoding and verifying the signed VP to ensure its integrity and correctness.
///
/// This flow illustrates how a holder can create a VP that satisfies a verifier's requirements, based on input descriptors.

#[test]
fn test_presentation_exchange_full_flow() {
    // Step 1: Create an issuer (typically the entity that issued the credential)
    let issuer = DidJwk::create(None).unwrap();
    let issuer_uri = issuer.clone().did.uri;

    // Step 2: Define a Presentation Definition (PD) that specifies the required input descriptors
    // In this case, the input descriptor specifies that the credential must contain a `credentialSubject.id` matching a DID JWK pattern.
    let presentation_definition = PresentationDefinition {
        id: "test_pd_id".to_string(),
        name: Some("Test Presentation Definition".to_string()),
        purpose: Some("Testing".to_string()),
        input_descriptors: vec![InputDescriptor {
            id: "test_input_1".to_string(),
            name: Some("Test Input 1".to_string()),
            purpose: Some("Testing Input 1".to_string()),
            constraints: Constraints {
                fields: vec![Field {
                    path: vec!["$.credentialSubject.id".to_string()],
                    filter: Some(Filter {
                        r#type: Some("string".to_string()),
                        pattern: Some("^did:jwk:.*$".to_string()),
                        const_value: None,
                        contains: None,
                    }),
                    id: None,
                    name: None,
                    purpose: None,
                    optional: None,
                    predicate: None,
                }],
            },
        }],
        submission_requirements: None,
    };

    // Step 3: Create a Verifiable Credential (VC) that contains a credential subject matching the PD criteria
    let vc_1 = VerifiableCredential::create(
        Issuer::from(issuer_uri.clone()),
        CredentialSubject::from(issuer_uri.clone()),
        Default::default(),
    )
    .unwrap();

    // Step 4: Sign the VC to generate a VC in JWT format
    let signed_vcjwt_1 = vc_1.sign(&issuer.clone(), None).unwrap();

    // Step 5: Collect the JWTs into a vector
    let vc_jwts = vec![signed_vcjwt_1.clone()];

    // Step 6: Select the credentials that match the PD's input descriptors
    let presentation_result = presentation_definition
        .create_presentation_from_credentials(&vc_jwts)
        .unwrap();

    // Step 7: Create the Verifiable Presentation (VP) with the selected credentials and additional data
    let holder = DidJwk::create(None).unwrap();
    let holder_uri = holder.clone().did.uri;

    // Additional data includes the presentation submission, which links the presentation to the PD
    let mut additional_data = HashMap::new();
    additional_data.insert(
        "presentation_submission".to_string(),
        json!(presentation_result.presentation_submission),
    );

    // Create VP with the matched credentials and additional data
    let vp_create_options = VerifiablePresentationCreateOptions {
        additional_data: Some(additional_data),
        ..Default::default()
    };

    // Generate the Verifiable Presentation
    let vp = VerifiablePresentation::create(
        holder_uri.clone(),
        presentation_result.matched_vc_jwts, // Use the selected credentials from the PD
        Some(vp_create_options)
    )
    .expect("Failed to create Verifiable Presentation");

    // Step 8: Sign the VP to generate a JWT format
    let vp_jwt = vp.sign(&holder.clone(), None).unwrap();

    // Step 9: Decode and verify the signed VP to ensure correctness
    let decoded_vp = VerifiablePresentation::from_vp_jwt(&vp_jwt, true)
        .expect("Failed to decode Verifiable Presentation JWT");

    // Step 10: Verify the holder matches the expected holder
    assert_eq!(decoded_vp.holder, holder_uri);

    // Step 11: Verify that the correct Verifiable Credential was included in the presentation
    assert_eq!(decoded_vp.verifiable_credential.len(), 1);
    assert_eq!(decoded_vp.verifiable_credential[0], signed_vcjwt_1);

    // Step 12: Retrieve the presentation_submission from the decoded VP's additional data
    let decoded_presentation_submission = decoded_vp
        .additional_data
        .as_ref()
        .and_then(|data| data.get("presentation_submission"));

    // Step 13: Check if the decoded presentation_submission is equal to the original one
    assert_eq!(
        decoded_presentation_submission,
        Some(&json!(presentation_result.presentation_submission)),
        "The presentation_submission in additional_data does not match the expected value"
    );
}
```