### PR TITLE
fix outside pr comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
           vector-regex: (\w+)
           fail-on-missing-vectors: false
           fail-on-failed-test-cases: true
-          comment-on-pr: true
+          comment-on-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
           package-name: web5-core-kt
           git-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -410,7 +410,7 @@ jobs:
           prettify-feature: true
           fail-on-missing-vectors: false
           fail-on-failed-test-cases: true
-          comment-on-pr: true
+          comment-on-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
           package-name: web5-rs
           git-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Rust Test Vector Results


### PR DESCRIPTION
Chad says:

Explanation:

github.event_name == 'pull_request': Checks if the event that triggered the workflow is a pull request.
github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name: Compares the repository names of the head (source) and base (target) of the pull request. If they are the same, it means the PR is from an inside account.
comment-on-pr: This input is now dynamically set to true only when the PR is from an inside account. Otherwise, it defaults to false.
This change ensures that the action will only attempt to comment on pull requests from inside accounts, avoiding permission issues or unwanted comments on PRs from outside contributors.