### PR TITLE
Convert to chrono

### DIFF
--- a/crates/web5/src/credentials/create.rs
+++ b/crates/web5/src/credentials/create.rs
@@ -110,6 +110,7 @@ mod tests {
     use mockito::Server;
     use regex::Regex;
     use std::collections::HashMap;
+    use chrono::Utc;
 
     const ISSUER_DID_URI: &str = "did:web:tbd.website";
     const SUBJECT_DID_URI: &str = "did:dht:qgmmpyjw5hwnqfgzn7wmrm33ady8gb8z9ideib6m9gj4ys6wny8y";
@@ -501,7 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_issuance_date_must_be_set() {
-        let issuance_date = SystemTime::now();
+        let issuance_date = Utc::now().into();
 
         let options = VerifiableCredentialCreateOptions {
             issuance_date: Some(issuance_date),
@@ -525,7 +526,7 @@ mod tests {
         .await
         .unwrap();
 
-        let now = SystemTime::now();
+        let now = Utc::now().into();
         let hundred_millis_ago = now - std::time::Duration::from_millis(100);
 
         assert!(vc.issuance_date >= hundred_millis_ago && vc.issuance_date <= now);
@@ -533,7 +534,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_expiration_date_must_be_set_if_supplied() {
-        let expiration_date = SystemTime::now();
+        let expiration_date = Utc::now().into();
         let options = VerifiableCredentialCreateOptions {
             expiration_date: Some(expiration_date),
             ..Default::default()

--- a/crates/web5/src/credentials/create.rs
+++ b/crates/web5/src/credentials/create.rs
@@ -107,10 +107,10 @@ mod tests {
     use crate::credentials::credential_schema::{CredentialSchema, CREDENTIAL_SCHEMA_TYPE};
     use crate::json::JsonValue;
     use crate::{credentials::issuer::ObjectIssuer, json::JsonObject};
+    use chrono::Utc;
     use mockito::Server;
     use regex::Regex;
     use std::collections::HashMap;
-    use chrono::Utc;
 
     const ISSUER_DID_URI: &str = "did:web:tbd.website";
     const SUBJECT_DID_URI: &str = "did:dht:qgmmpyjw5hwnqfgzn7wmrm33ady8gb8z9ideib6m9gj4ys6wny8y";
@@ -502,7 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_issuance_date_must_be_set() {
-        let issuance_date = Utc::now().into();
+        let issuance_date: SystemTime = Utc::now().into();
 
         let options = VerifiableCredentialCreateOptions {
             issuance_date: Some(issuance_date),
@@ -526,7 +526,7 @@ mod tests {
         .await
         .unwrap();
 
-        let now = Utc::now().into();
+        let now: SystemTime = Utc::now().into();
         let hundred_millis_ago = now - std::time::Duration::from_millis(100);
 
         assert!(vc.issuance_date >= hundred_millis_ago && vc.issuance_date <= now);
@@ -534,7 +534,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_expiration_date_must_be_set_if_supplied() {
-        let expiration_date = Utc::now().into();
+        let expiration_date: SystemTime = Utc::now().into();
         let options = VerifiableCredentialCreateOptions {
             expiration_date: Some(expiration_date),
             ..Default::default()

--- a/crates/web5/src/credentials/data_model_validation.rs
+++ b/crates/web5/src/credentials/data_model_validation.rs
@@ -1,5 +1,6 @@
 use std::time::SystemTime;
 
+use chrono::Utc;
 use super::{
     verifiable_credential_1_1::{VerifiableCredential, BASE_CONTEXT, BASE_TYPE},
     VerificationError,
@@ -39,7 +40,7 @@ pub fn validate_vc_data_model(
         ));
     }
 
-    let now = SystemTime::now();
+    let now: SystemTime = Utc::now().into();
     if vc.issuance_date > now {
         return Err(VerificationError::DataModelValidationError(
             "issuance date in future".to_string(),

--- a/crates/web5/src/credentials/sign.rs
+++ b/crates/web5/src/credentials/sign.rs
@@ -7,7 +7,8 @@ use crate::{
     jose::{Jwt, JwtClaims},
     json::{JsonValue, ToJsonValue},
 };
-use std::{collections::HashMap, time::SystemTime};
+use std::{collections::HashMap};
+use chrono::Utc;
 
 pub fn sign_with_did(
     vc: &VerifiableCredential,
@@ -43,7 +44,7 @@ pub fn sign_with_did(
         jti: Some(vc.id.clone()),
         sub: Some(vc.credential_subject.id.clone()),
         nbf: Some(vc.issuance_date),
-        iat: Some(SystemTime::now()),
+        iat: Some(Utc::now().into()),
         exp: vc.expiration_date,
         additional_properties: Some(additional_properties),
     };

--- a/crates/web5/src/dids/methods/did_dht/bep44.rs
+++ b/crates/web5/src/dids/methods/did_dht/bep44.rs
@@ -8,6 +8,7 @@ use crate::{
     errors::Web5Error,
 };
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use chrono::Utc;
 
 /// Minimum size of a bep44 encoded message
 /// Signature is 64 bytes and seq is 8 byets
@@ -85,8 +86,8 @@ impl Bep44Message {
         if message_len > MAX_V_LEN {
             return Err(Bep44EncodingError::Size(message_len));
         }
-
-        let seq = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let now: SystemTime = Utc::now().into();
+        let seq = now.duration_since(UNIX_EPOCH)?.as_secs();
 
         let signable = signable(seq, message);
         let sig = sign(signable)?;


### PR DESCRIPTION
This converts system time now() to chrono now(), so that we dont get a wasm black hole error (in tbdex-rs), this will then be used in tbdex-rs